### PR TITLE
CDP: multi-target JS execution and robust cleanup

### DIFF
--- a/src-tauri/src/cdp_client.rs
+++ b/src-tauri/src/cdp_client.rs
@@ -231,12 +231,14 @@ fn is_discord_target(target: &CdpTarget) -> bool {
 fn select_discord_targets<'a>(targets: &'a [CdpTarget]) -> Vec<&'a CdpTarget> {
     let mut selected_targets: Vec<&CdpTarget> = targets
         .iter()
-        .filter(|t| is_discord_target(t))
+        .filter(|t| is_discord_target(t) && t.web_socket_debugger_url.is_some())
         .collect();
 
     // Fallback: keep old behavior if detection fails and use the best single target.
     if selected_targets.is_empty() {
-        if let Some(target) = pick_discord_target(targets) {
+        if let Some(target) = pick_discord_target(targets)
+            .filter(|t| t.web_socket_debugger_url.is_some())
+        {
             selected_targets.push(target);
         }
     }
@@ -683,12 +685,21 @@ mod tests {
     use super::*;
 
     fn mk_target(target_type: &str, title: &str, url: &str) -> CdpTarget {
+        mk_target_opt_ws(target_type, title, url, Some("ws://example".to_string()))
+    }
+
+    fn mk_target_opt_ws(
+        target_type: &str,
+        title: &str,
+        url: &str,
+        ws: Option<String>,
+    ) -> CdpTarget {
         CdpTarget {
             id: format!("{}-{}", target_type, title),
             target_type: target_type.to_string(),
             title: title.to_string(),
             url: url.to_string(),
-            web_socket_debugger_url: Some("ws://example".to_string()),
+            web_socket_debugger_url: ws,
         }
     }
     
@@ -760,5 +771,25 @@ mod tests {
         let fallback = select_discord_targets(&no_match_targets);
         assert_eq!(fallback.len(), 1);
         assert_eq!(fallback[0].url, "https://example.com/a");
+
+        let with_missing_ws = vec![
+            mk_target_opt_ws(
+                "page",
+                "Discord Main",
+                "https://discord.com/app",
+                None,
+            ),
+            mk_target("page", "Discord Secondary", "https://discordapp.com/channels/@me"),
+        ];
+        let filtered = select_discord_targets(&with_missing_ws);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].title, "Discord Secondary");
+
+        let fallback_missing_ws = vec![
+            mk_target_opt_ws("page", "Page A", "https://example.com/a", None),
+            mk_target_opt_ws("page", "Page B", "https://example.com/b", None),
+        ];
+        let fallback_none = select_discord_targets(&fallback_missing_ws);
+        assert_eq!(fallback_none.len(), 0);
     }
 }

--- a/src-tauri/src/cdp_client.rs
+++ b/src-tauri/src/cdp_client.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{future::join_all, SinkExt, StreamExt};
 
 /// Default CDP debugging port
 pub const DEFAULT_CDP_PORT: u16 = 9223;
@@ -226,6 +226,22 @@ fn is_discord_target(target: &CdpTarget) -> bool {
     (title_lower.contains("discord") && !title_lower.contains("updater"))
         || url_lower.contains("discord.com")
         || url_lower.contains("discordapp.com")
+}
+
+fn select_discord_targets<'a>(targets: &'a [CdpTarget]) -> Vec<&'a CdpTarget> {
+    let mut selected_targets: Vec<&CdpTarget> = targets
+        .iter()
+        .filter(|t| is_discord_target(t))
+        .collect();
+
+    // Fallback: keep old behavior if detection fails and use the best single target.
+    if selected_targets.is_empty() {
+        if let Some(target) = pick_discord_target(targets) {
+            selected_targets.push(target);
+        }
+    }
+
+    selected_targets
 }
 
 /// Get SuperProperties via CDP
@@ -531,17 +547,7 @@ pub async fn execute_js_via_all_discord_targets(
 
     let targets = get_cdp_targets(port).await?;
 
-    let mut selected_targets: Vec<&CdpTarget> = targets
-        .iter()
-        .filter(|t| is_discord_target(t))
-        .collect();
-
-    // Fallback: keep old behavior if detection fails and use the best single target.
-    if selected_targets.is_empty() {
-        if let Some(target) = pick_discord_target(&targets) {
-            selected_targets.push(target);
-        }
-    }
+    let selected_targets = select_discord_targets(&targets);
 
     if selected_targets.is_empty() {
         anyhow::bail!("No CDP page targets found");
@@ -550,9 +556,9 @@ pub async fn execute_js_via_all_discord_targets(
     log(LogLevel::Debug, LogCategory::TokenExtraction,
         &format!("execute_js_via_all_discord_targets: running on {} target(s)", selected_targets.len()), None);
 
-    let mut results = Vec::with_capacity(selected_targets.len());
-
-    for target in selected_targets {
+    // Execute all target evaluations concurrently. Each task still respects per-target
+    // timeout via execute_js_via_ws().
+    let tasks = selected_targets.into_iter().map(|target| async move {
         let mut item = CdpTargetExecutionResult {
             target_title: target.title.clone(),
             target_url: target.url.clone(),
@@ -569,8 +575,10 @@ pub async fn execute_js_via_all_discord_targets(
             item.error = Some("Target has no WebSocket URL".to_string());
         }
 
-        results.push(item);
-    }
+        item
+    });
+
+    let results = join_all(tasks).await;
 
     Ok(results)
 }
@@ -673,6 +681,16 @@ async fn execute_js_via_ws(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn mk_target(target_type: &str, title: &str, url: &str) -> CdpTarget {
+        CdpTarget {
+            id: format!("{}-{}", target_type, title),
+            target_type: target_type.to_string(),
+            title: title.to_string(),
+            url: url.to_string(),
+            web_socket_debugger_url: Some("ws://example".to_string()),
+        }
+    }
     
     #[test]
     fn test_pick_discord_target() {
@@ -696,5 +714,51 @@ mod tests {
         let picked = pick_discord_target(&targets);
         assert!(picked.is_some());
         assert_eq!(picked.unwrap().id, "2");
+    }
+
+    #[test]
+    fn test_is_discord_target_domain_and_updater_filter() {
+        let discord_app = mk_target("page", "Some Title", "https://discordapp.com/channels/@me");
+        let discord_updater = mk_target("page", "Discord Updater", "about:blank");
+        let worker = mk_target("worker", "Discord", "https://discord.com/app");
+
+        assert!(is_discord_target(&discord_app));
+        assert!(!is_discord_target(&discord_updater));
+        assert!(!is_discord_target(&worker));
+    }
+
+    #[test]
+    fn test_pick_discord_target_fallback_to_first_page() {
+        let targets = vec![
+            mk_target("page", "Not Discord 1", "https://example.com/a"),
+            mk_target("page", "Not Discord 2", "https://example.com/b"),
+        ];
+
+        let picked = pick_discord_target(&targets);
+        assert!(picked.is_some());
+        assert_eq!(picked.unwrap().url, "https://example.com/a");
+    }
+
+    #[test]
+    fn test_select_discord_targets_filters_and_fallbacks() {
+        let targets = vec![
+            mk_target("page", "Discord Updater", "about:blank"),
+            mk_target("page", "Discord", "https://discord.com/app"),
+            mk_target("page", "Other", "https://discordapp.com/channels/@me"),
+            mk_target("page", "Other Site", "https://example.com"),
+        ];
+
+        let selected = select_discord_targets(&targets);
+        assert_eq!(selected.len(), 2);
+        assert!(selected.iter().any(|t| t.url.contains("discord.com")));
+        assert!(selected.iter().any(|t| t.url.contains("discordapp.com")));
+
+        let no_match_targets = vec![
+            mk_target("page", "Page A", "https://example.com/a"),
+            mk_target("page", "Page B", "https://example.com/b"),
+        ];
+        let fallback = select_discord_targets(&no_match_targets);
+        assert_eq!(fallback.len(), 1);
+        assert_eq!(fallback[0].url, "https://example.com/a");
     }
 }

--- a/src-tauri/src/cdp_client.rs
+++ b/src-tauri/src/cdp_client.rs
@@ -42,6 +42,15 @@ pub struct CdpStatus {
     pub error: Option<String>,
 }
 
+/// Result of executing JS on a specific CDP target.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CdpTargetExecutionResult {
+    pub target_title: String,
+    pub target_url: String,
+    pub result: Option<String>,
+    pub error: Option<String>,
+}
+
 /// Captured Discord API request headers via CDP Network interception
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CdpCapturedHeaders {
@@ -196,18 +205,27 @@ fn pick_discord_target(targets: &[CdpTarget]) -> Option<&CdpTarget> {
     
     // Find Discord main application
     for target in &pages {
-        let title_lower = target.title.to_lowercase();
-        let url_lower = target.url.to_lowercase();
-        
-        if (title_lower.contains("discord") && !title_lower.contains("updater"))
-            || url_lower.contains("discord.com")
-        {
+        if is_discord_target(target) {
             return Some(target);
         }
     }
     
     // Fallback: return the first page
     pages.first().copied()
+}
+
+/// Return true if this target looks like a Discord app page.
+fn is_discord_target(target: &CdpTarget) -> bool {
+    if target.target_type != "page" {
+        return false;
+    }
+
+    let title_lower = target.title.to_lowercase();
+    let url_lower = target.url.to_lowercase();
+
+    (title_lower.contains("discord") && !title_lower.contains("updater"))
+        || url_lower.contains("discord.com")
+        || url_lower.contains("discordapp.com")
 }
 
 /// Get SuperProperties via CDP
@@ -495,6 +513,75 @@ pub async fn execute_js_via_cdp(port: u16, js_code: &str, await_promise: bool, t
         .web_socket_debugger_url
         .as_ref()
         .context("Target has no WebSocket URL")?;
+
+    execute_js_via_ws(ws_url, js_code, await_promise, timeout_secs).await
+}
+
+/// Execute JS on every Discord-like CDP page target.
+///
+/// This is used for best-effort cleanup, ensuring spoof state is removed even when
+/// Discord exposes multiple page targets and the "active" one changes between calls.
+pub async fn execute_js_via_all_discord_targets(
+    port: u16,
+    js_code: &str,
+    await_promise: bool,
+    timeout_secs: u64,
+) -> Result<Vec<CdpTargetExecutionResult>> {
+    use crate::logger::{log, LogLevel, LogCategory};
+
+    let targets = get_cdp_targets(port).await?;
+
+    let mut selected_targets: Vec<&CdpTarget> = targets
+        .iter()
+        .filter(|t| is_discord_target(t))
+        .collect();
+
+    // Fallback: keep old behavior if detection fails and use the best single target.
+    if selected_targets.is_empty() {
+        if let Some(target) = pick_discord_target(&targets) {
+            selected_targets.push(target);
+        }
+    }
+
+    if selected_targets.is_empty() {
+        anyhow::bail!("No CDP page targets found");
+    }
+
+    log(LogLevel::Debug, LogCategory::TokenExtraction,
+        &format!("execute_js_via_all_discord_targets: running on {} target(s)", selected_targets.len()), None);
+
+    let mut results = Vec::with_capacity(selected_targets.len());
+
+    for target in selected_targets {
+        let mut item = CdpTargetExecutionResult {
+            target_title: target.title.clone(),
+            target_url: target.url.clone(),
+            result: None,
+            error: None,
+        };
+
+        if let Some(ws_url) = target.web_socket_debugger_url.as_ref() {
+            match execute_js_via_ws(ws_url, js_code, await_promise, timeout_secs).await {
+                Ok(result) => item.result = Some(result),
+                Err(e) => item.error = Some(e.to_string()),
+            }
+        } else {
+            item.error = Some("Target has no WebSocket URL".to_string());
+        }
+
+        results.push(item);
+    }
+
+    Ok(results)
+}
+
+async fn execute_js_via_ws(
+    ws_url: &str,
+    js_code: &str,
+    await_promise: bool,
+    timeout_secs: u64,
+) -> Result<String> {
+    use crate::logger::{log, LogLevel, LogCategory};
 
     let (ws_stream, _) = connect_async(ws_url)
         .await

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -649,8 +649,15 @@ const JS_CLEANUP_SPOOF: &str = r#"
         if (dqh._origGetRunningGames) {
             dqh.RunningGameStore.getRunningGames = dqh._origGetRunningGames;
         }
-        if (dqh._origGetGameForPID) {
+        if (typeof dqh._origGetGameForPID === "function") {
             dqh.RunningGameStore.getGameForPID = dqh._origGetGameForPID;
+        } else {
+            // If the original store had no getGameForPID, remove the spoofed method.
+            try {
+                delete dqh.RunningGameStore.getGameForPID;
+            } catch(e) {
+                dqh.RunningGameStore.getGameForPID = undefined;
+            }
         }
         if (dqh._origGetStreamerActiveStreamMetadata) {
             dqh.ApplicationStreamingStore.getStreamerActiveStreamMetadata = dqh._origGetStreamerActiveStreamMetadata;
@@ -683,6 +690,25 @@ const JS_CLEANUP_SPOOF: &str = r#"
 
         delete window.__dqh_cdp;
         return JSON.stringify({ success: true });
+    } catch (e) {
+        return JSON.stringify({ success: false, error: String(e) });
+    }
+})()
+"#;
+
+/// JavaScript: verify whether spoof state is still present in this page target.
+const JS_VERIFY_CLEANUP_STATE: &str = r#"
+(() => {
+    try {
+        const dqh = window.__dqh_cdp;
+        return JSON.stringify({
+            success: true,
+            dqhPresent: !!dqh,
+            spoofActive: !!dqh?._spoofActive,
+            fakeGamePresent: !!dqh?._fakeGame,
+            hasDispatchHook: !!dqh?._origDispatch,
+            broadPatchCount: Array.isArray(dqh?._broadPatched) ? dqh._broadPatched.length : 0
+        });
     } catch (e) {
         return JSON.stringify({ success: false, error: String(e) });
     }
@@ -725,21 +751,159 @@ async fn cdp_cleanup(port: u16) {
 
     // Try cleanup up to 2 times — CDP connection can be flaky
     for attempt in 1..=2 {
-        match cdp_client::execute_js_via_cdp(port, JS_CLEANUP_SPOOF, false, 5).await {
-            Ok(result) => {
-                log(LogLevel::Info, LogCategory::TokenExtraction,
-                    &format!("CDP cleanup result (attempt {}): {}", attempt, result), None);
-                return;
+        let mut cleanup_success_count = 0usize;
+
+        match cdp_client::execute_js_via_all_discord_targets(port, JS_CLEANUP_SPOOF, false, 5).await {
+            Ok(results) => {
+                let mut error_count = 0usize;
+
+                for item in results {
+                    if let Some(err) = item.error {
+                        error_count += 1;
+                        log(LogLevel::Warn, LogCategory::TokenExtraction,
+                            &format!(
+                                "CDP cleanup target error (attempt {}): target='{}' url='{}' err={}",
+                                attempt, item.target_title, item.target_url, err
+                            ),
+                            None,
+                        );
+                        continue;
+                    }
+
+                    let raw = item.result.unwrap_or_default();
+                    let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap_or_default();
+                    let target_success = parsed.get("success") == Some(&serde_json::json!(true));
+
+                    if target_success {
+                        cleanup_success_count += 1;
+                        log(LogLevel::Info, LogCategory::TokenExtraction,
+                            &format!(
+                                "CDP cleanup target ok (attempt {}): target='{}' url='{}' result={}",
+                                attempt, item.target_title, item.target_url, raw
+                            ),
+                            None,
+                        );
+                    } else {
+                        error_count += 1;
+                        log(LogLevel::Warn, LogCategory::TokenExtraction,
+                            &format!(
+                                "CDP cleanup target returned failure (attempt {}): target='{}' url='{}' result={}",
+                                attempt, item.target_title, item.target_url, raw
+                            ),
+                            None,
+                        );
+                    }
+                }
+
+                if cleanup_success_count == 0 {
+                    log(LogLevel::Warn, LogCategory::TokenExtraction,
+                        &format!(
+                            "CDP cleanup had no successful target (attempt {}, failed_targets={})",
+                            attempt, error_count
+                        ),
+                        None,
+                    );
+                }
             }
             Err(e) => {
                 log(LogLevel::Warn, LogCategory::TokenExtraction,
-                    &format!("CDP cleanup failed (attempt {}): {}", attempt, e), None);
-                if attempt < 2 {
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-                }
+                    &format!("CDP cleanup request failed (attempt {}): {}", attempt, e), None);
             }
         }
+
+        // Verify cleanup state across all page targets.
+        match cdp_client::execute_js_via_all_discord_targets(port, JS_VERIFY_CLEANUP_STATE, false, 5).await {
+            Ok(results) => {
+                let mut verify_checked = 0usize;
+                let mut verify_dirty = 0usize;
+                let mut verify_errors = 0usize;
+
+                for item in results {
+                    if let Some(err) = item.error {
+                        verify_errors += 1;
+                        log(LogLevel::Warn, LogCategory::TokenExtraction,
+                            &format!(
+                                "CDP cleanup verify target error (attempt {}): target='{}' url='{}' err={}",
+                                attempt, item.target_title, item.target_url, err
+                            ),
+                            None,
+                        );
+                        continue;
+                    }
+
+                    let raw = item.result.unwrap_or_default();
+                    let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap_or_default();
+                    let verify_success = parsed.get("success") == Some(&serde_json::json!(true));
+
+                    if !verify_success {
+                        verify_dirty += 1;
+                        log(LogLevel::Warn, LogCategory::TokenExtraction,
+                            &format!(
+                                "CDP cleanup verify parse failure (attempt {}): target='{}' url='{}' result={}",
+                                attempt, item.target_title, item.target_url, raw
+                            ),
+                            None,
+                        );
+                        continue;
+                    }
+
+                    verify_checked += 1;
+                    let dqh_present = parsed.get("dqhPresent").and_then(|v| v.as_bool()).unwrap_or(false);
+                    let spoof_active = parsed.get("spoofActive").and_then(|v| v.as_bool()).unwrap_or(false);
+                    let fake_game_present = parsed.get("fakeGamePresent").and_then(|v| v.as_bool()).unwrap_or(false);
+                    let has_dispatch_hook = parsed.get("hasDispatchHook").and_then(|v| v.as_bool()).unwrap_or(false);
+                    let broad_patch_count = parsed.get("broadPatchCount").and_then(|v| v.as_u64()).unwrap_or(0);
+
+                    let target_dirty = dqh_present || spoof_active || fake_game_present || has_dispatch_hook || broad_patch_count > 0;
+                    if target_dirty {
+                        verify_dirty += 1;
+                        log(LogLevel::Warn, LogCategory::TokenExtraction,
+                            &format!(
+                                "CDP cleanup verify found residual state (attempt {}): target='{}' url='{}' dqhPresent={} spoofActive={} fakeGamePresent={} hasDispatchHook={} broadPatchCount={}",
+                                attempt,
+                                item.target_title,
+                                item.target_url,
+                                dqh_present,
+                                spoof_active,
+                                fake_game_present,
+                                has_dispatch_hook,
+                                broad_patch_count
+                            ),
+                            None,
+                        );
+                    }
+                }
+
+                if verify_dirty == 0 && verify_checked > 0 {
+                    log(LogLevel::Info, LogCategory::TokenExtraction,
+                        &format!(
+                            "CDP cleanup verified (attempt {}): checked_targets={}, cleanup_success_targets={}, verify_errors={}",
+                            attempt, verify_checked, cleanup_success_count, verify_errors
+                        ),
+                        None,
+                    );
+                    return;
+                }
+
+                log(LogLevel::Warn, LogCategory::TokenExtraction,
+                    &format!(
+                        "CDP cleanup verification incomplete (attempt {}): checked_targets={}, dirty_targets={}, verify_errors={}, cleanup_success_targets={}",
+                        attempt, verify_checked, verify_dirty, verify_errors, cleanup_success_count
+                    ),
+                    None,
+                );
+            }
+            Err(e) => {
+                log(LogLevel::Warn, LogCategory::TokenExtraction,
+                    &format!("CDP cleanup verify request failed (attempt {}): {}", attempt, e), None);
+            }
+        }
+
+        if attempt < 2 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
     }
+
     log(LogLevel::Error, LogCategory::TokenExtraction,
         "CDP cleanup failed after all retries — spoof may still be active in Discord!", None);
 }
@@ -834,6 +998,10 @@ pub async fn complete_play_quest_via_cdp(
 
     log(LogLevel::Info, LogCategory::TokenExtraction,
         &format!("CDP play quest: quest_id={}, app_id={}, app_name={}", quest_id, app_id, app_name), None);
+
+    // Defensive pre-cleanup: prevent stale spoof state from a previous run from leaking
+    // into the new quest session.
+    cdp_cleanup(port).await;
 
     // 1. Init modules
     cdp_init_modules(port).await
@@ -943,6 +1111,9 @@ pub async fn complete_stream_quest_via_cdp(
     log(LogLevel::Info, LogCategory::TokenExtraction,
         &format!("CDP stream quest: quest_id={}, app_id={}", quest_id, app_id), None);
 
+    // Defensive pre-cleanup: ensure previous spoof state is removed before applying new patches.
+    cdp_cleanup(port).await;
+
     // 1. Init modules
     cdp_init_modules(port).await
         .context("Failed to initialize CDP modules for stream quest")?;
@@ -1048,6 +1219,9 @@ pub async fn complete_video_quest_via_cdp(
     log(LogLevel::Info, LogCategory::TokenExtraction,
         &format!("CDP video quest: quest_id={}, target={}s, initial={:.0}s", 
             quest_id, seconds_needed, initial_progress), None);
+
+    // Defensive pre-cleanup for cross-quest consistency.
+    cdp_cleanup(port).await;
 
     // 1. Init modules
     cdp_init_modules(port).await

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -874,7 +874,7 @@ async fn cdp_cleanup(port: u16) {
                     }
                 }
 
-                if verify_dirty == 0 && verify_checked > 0 {
+                if verify_dirty == 0 && verify_checked > 0 && verify_errors == 0 {
                     log(LogLevel::Info, LogCategory::TokenExtraction,
                         &format!(
                             "CDP cleanup verified (attempt {}): checked_targets={}, cleanup_success_targets={}, verify_errors={}",


### PR DESCRIPTION
Add multi-target CDP execution and verification. Introduces CdpTargetExecutionResult, is_discord_target helper, and execute_js_via_all_discord_targets (with internal execute_js_via_ws) to run JS across all Discord-like page targets. Improve cdp_cleanup to run cleanup on every target, verify residual spoof state, log per-target results, and retry as needed. Make JS cleanup tolerant of missing getGameForPID by deleting the spoofed method when appropriate. Add defensive pre-cleanup calls before play/stream/video quest flows.