### PR TITLE
Add system proxy detection and HTTP timeouts

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -95,6 +95,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +700,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "anyhow",
+ "arc-swap",
  "base64 0.22.1",
  "cbc",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "url",
  "uuid",
  "windows 0.62.2",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1589,9 +1590,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3716,6 +3719,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5083,6 +5107,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ base64 = "0.22"
 aes-gcm = "0.10"
 rand = "0.10"
 anyhow = "1"
+arc-swap = "1.7"
 ctrlc = "3.5"
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ discord-sdk = "0.4.0"
 once_cell = "1.21"
 
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.13", default-features = false, features = ["native-tls", "json", "charset", "http2"] }
+reqwest = { version = "0.13", default-features = false, features = ["native-tls", "json", "charset", "http2", "system-proxy"] }
 regex = "1"
 base64 = "0.22"
 aes-gcm = "0.10"
@@ -41,6 +41,7 @@ windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Storage_Streams",
 ] }
+windows-registry = "0.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "3"

--- a/src-tauri/src/cdp_client.rs
+++ b/src-tauri/src/cdp_client.rs
@@ -177,6 +177,7 @@ pub async fn check_cdp_available(port: u16) -> CdpStatus {
 /// Get CDP target list
 async fn get_cdp_targets(port: u16) -> Result<Vec<CdpTarget>> {
     let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(2))
         .timeout(Duration::from_secs(3))
         .build()?;
     

--- a/src-tauri/src/discord_api.rs
+++ b/src-tauri/src/discord_api.rs
@@ -3,27 +3,108 @@ use anyhow::{Context, Result};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use reqwest::{Method, RequestBuilder};
 use base64::Engine;
-use std::sync::Arc;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 const DISCORD_API_BASE: &str = "https://discord.com/api/v9";
-#[allow(dead_code)]
-const USER_AGENT_STRING: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
+const USER_AGENT_STRING: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) discord/1.0.9219 Chrome/138.0.7204.251 Electron/37.6.0 Safari/537.36";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ProxyState {
+    fingerprint: u64,
+    has_proxy: bool,
+}
+
+impl ProxyState {
+    fn current() -> Self {
+        let mut parts = Vec::new();
+
+        let http_proxy = std::env::var("HTTP_PROXY").unwrap_or_default();
+        let https_proxy = std::env::var("HTTPS_PROXY").unwrap_or_default();
+        let all_proxy = std::env::var("ALL_PROXY").unwrap_or_default();
+        let no_proxy = std::env::var("NO_PROXY").unwrap_or_default();
+        let http_proxy_lower = std::env::var("http_proxy").unwrap_or_default();
+        let https_proxy_lower = std::env::var("https_proxy").unwrap_or_default();
+        let all_proxy_lower = std::env::var("all_proxy").unwrap_or_default();
+        let no_proxy_lower = std::env::var("no_proxy").unwrap_or_default();
+
+        parts.push(format!("http_proxy={}", http_proxy));
+        parts.push(format!("https_proxy={}", https_proxy));
+        parts.push(format!("all_proxy={}", all_proxy));
+        parts.push(format!("no_proxy={}", no_proxy));
+        parts.push(format!("http_proxy_lower={}", http_proxy_lower));
+        parts.push(format!("https_proxy_lower={}", https_proxy_lower));
+        parts.push(format!("all_proxy_lower={}", all_proxy_lower));
+        parts.push(format!("no_proxy_lower={}", no_proxy_lower));
+
+        let mut has_proxy = !http_proxy.trim().is_empty()
+            || !https_proxy.trim().is_empty()
+            || !all_proxy.trim().is_empty()
+            || !http_proxy_lower.trim().is_empty()
+            || !https_proxy_lower.trim().is_empty()
+            || !all_proxy_lower.trim().is_empty();
+
+        #[cfg(windows)]
+        {
+            let maybe_settings = windows_registry::CURRENT_USER
+                .open("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings");
+
+            match maybe_settings {
+                Ok(settings) => {
+                    let proxy_enable = settings.get_u32("ProxyEnable").unwrap_or(0);
+                    let proxy_server = settings.get_string("ProxyServer").unwrap_or_default();
+                    let proxy_override = settings.get_string("ProxyOverride").unwrap_or_default();
+                    let auto_config_url = settings.get_string("AutoConfigURL").unwrap_or_default();
+                    let auto_detect = settings.get_u32("AutoDetect").unwrap_or(0);
+
+                    parts.push(format!("proxy_enable={}", proxy_enable));
+                    parts.push(format!("proxy_server={}", proxy_server));
+                    parts.push(format!("proxy_override={}", proxy_override));
+                    parts.push(format!("auto_config_url={}", auto_config_url));
+                    parts.push(format!("auto_detect={}", auto_detect));
+
+                    has_proxy = has_proxy
+                        || (proxy_enable == 1 && !proxy_server.trim().is_empty())
+                        || !auto_config_url.trim().is_empty()
+                        || auto_detect == 1;
+                }
+                Err(_) => {
+                    parts.push("registry_unavailable=1".to_string());
+                }
+            }
+        }
+
+        let raw = parts.join("|");
+        let mut hasher = DefaultHasher::new();
+        raw.hash(&mut hasher);
+
+        Self {
+            fingerprint: hasher.finish(),
+            has_proxy,
+        }
+    }
+}
+
+struct HttpClientState {
+    client: reqwest::Client,
+    proxy_state: ProxyState,
+}
 
 /// Discord API client
 #[derive(Clone)]
 pub struct DiscordApiClient {
-    client: Arc<reqwest::Client>,
-    #[allow(dead_code)]
+    http: Arc<Mutex<HttpClientState>>,
     token: String,
 }
 
 impl DiscordApiClient {
-    /// Create a new API client
-    pub fn new(token: String) -> Result<Self> {
+    fn build_default_headers(token: &str) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,
-            HeaderValue::from_str(&token).context("Invalid token format")?,
+            HeaderValue::from_str(token).context("Invalid token format")?,
         );
         headers.insert(
             CONTENT_TYPE,
@@ -31,7 +112,7 @@ impl DiscordApiClient {
         );
         headers.insert(
             USER_AGENT,
-            HeaderValue::from_static("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) discord/1.0.9219 Chrome/138.0.7204.251 Electron/37.6.0 Safari/537.36"),
+            HeaderValue::from_static(USER_AGENT_STRING),
         );
         // Note: X-Super-Properties is no longer set here, but dynamically obtained on each request
         // This ensures the latest validation parameters (including data obtained from CDP) are used
@@ -52,15 +133,89 @@ impl DiscordApiClient {
             HeaderValue::from_static("*/*"),
         );
 
-        let client = reqwest::Client::builder()
+        Ok(headers)
+    }
+
+    fn build_http_client(token: &str) -> Result<reqwest::Client> {
+        let headers = Self::build_default_headers(token)?;
+
+        reqwest::Client::builder()
             .default_headers(headers)
+            .connect_timeout(Duration::from_secs(8))
+            .timeout(Duration::from_secs(20))
             .build()
-            .context("Could not create HTTP client")?;
+            .context("Could not create HTTP client")
+    }
+
+    /// Create a new API client
+    pub fn new(token: String) -> Result<Self> {
+        use crate::logger::{log, LogCategory, LogLevel};
+
+        let proxy_state = ProxyState::current();
+        let client = Self::build_http_client(&token)?;
+
+        log(
+            LogLevel::Info,
+            LogCategory::Api,
+            "HTTP client initialized",
+            Some(if proxy_state.has_proxy {
+                "system proxy detected"
+            } else {
+                "no system proxy detected"
+            }),
+        );
 
         Ok(Self {
-            client: Arc::new(client),
+            http: Arc::new(Mutex::new(HttpClientState {
+                client,
+                proxy_state,
+            })),
             token,
         })
+    }
+
+    fn current_client(&self) -> reqwest::Client {
+        use crate::logger::{log, LogCategory, LogLevel};
+
+        let latest_proxy_state = ProxyState::current();
+        let mut state = self
+            .http
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        if state.proxy_state != latest_proxy_state {
+            let details = format!(
+                "fingerprint={} -> {}, has_proxy={} -> {}",
+                state.proxy_state.fingerprint,
+                latest_proxy_state.fingerprint,
+                state.proxy_state.has_proxy,
+                latest_proxy_state.has_proxy
+            );
+
+            log(
+                LogLevel::Info,
+                LogCategory::Api,
+                "System proxy state changed, rebuilding HTTP client",
+                Some(&details),
+            );
+
+            match Self::build_http_client(&self.token) {
+                Ok(client) => {
+                    state.client = client;
+                    state.proxy_state = latest_proxy_state;
+                }
+                Err(err) => {
+                    log(
+                        LogLevel::Warn,
+                        LogCategory::Api,
+                        "Failed to rebuild HTTP client after proxy change; using previous client",
+                        Some(&err.to_string()),
+                    );
+                }
+            }
+        }
+
+        state.client.clone()
     }
 
     /// Get the current X-Super-Properties value (dynamically obtained to ensure latest data)
@@ -95,7 +250,7 @@ impl DiscordApiClient {
 
     /// Centralized request builder to enforce security headers
     fn request(&self, method: Method, url: &str) -> RequestBuilder {
-        self.client
+        self.current_client()
             .request(method, url)
             .header("x-super-properties", self.get_super_properties_header())
     }

--- a/src-tauri/src/discord_api.rs
+++ b/src-tauri/src/discord_api.rs
@@ -1,15 +1,18 @@
 use crate::models::*;
 use anyhow::{Context, Result};
+use arc_swap::ArcSwap;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use reqwest::{Method, RequestBuilder};
 use base64::Engine;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 const DISCORD_API_BASE: &str = "https://discord.com/api/v9";
 const USER_AGENT_STRING: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) discord/1.0.9219 Chrome/138.0.7204.251 Electron/37.6.0 Safari/537.36";
+const PROXY_STATE_CHECK_INTERVAL_MS: u64 = 5_000;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ProxyState {
@@ -18,8 +21,13 @@ struct ProxyState {
 }
 
 impl ProxyState {
+    fn hash_setting(hasher: &mut DefaultHasher, key: &str, value: &str) {
+        key.hash(hasher);
+        value.trim().hash(hasher);
+    }
+
     fn current() -> Self {
-        let mut parts = Vec::new();
+        let mut hasher = DefaultHasher::new();
 
         let http_proxy = std::env::var("HTTP_PROXY").unwrap_or_default();
         let https_proxy = std::env::var("HTTPS_PROXY").unwrap_or_default();
@@ -30,14 +38,14 @@ impl ProxyState {
         let all_proxy_lower = std::env::var("all_proxy").unwrap_or_default();
         let no_proxy_lower = std::env::var("no_proxy").unwrap_or_default();
 
-        parts.push(format!("http_proxy={}", http_proxy));
-        parts.push(format!("https_proxy={}", https_proxy));
-        parts.push(format!("all_proxy={}", all_proxy));
-        parts.push(format!("no_proxy={}", no_proxy));
-        parts.push(format!("http_proxy_lower={}", http_proxy_lower));
-        parts.push(format!("https_proxy_lower={}", https_proxy_lower));
-        parts.push(format!("all_proxy_lower={}", all_proxy_lower));
-        parts.push(format!("no_proxy_lower={}", no_proxy_lower));
+        Self::hash_setting(&mut hasher, "HTTP_PROXY", &http_proxy);
+        Self::hash_setting(&mut hasher, "HTTPS_PROXY", &https_proxy);
+        Self::hash_setting(&mut hasher, "ALL_PROXY", &all_proxy);
+        Self::hash_setting(&mut hasher, "NO_PROXY", &no_proxy);
+        Self::hash_setting(&mut hasher, "http_proxy", &http_proxy_lower);
+        Self::hash_setting(&mut hasher, "https_proxy", &https_proxy_lower);
+        Self::hash_setting(&mut hasher, "all_proxy", &all_proxy_lower);
+        Self::hash_setting(&mut hasher, "no_proxy", &no_proxy_lower);
 
         let mut has_proxy = !http_proxy.trim().is_empty()
             || !https_proxy.trim().is_empty()
@@ -59,11 +67,13 @@ impl ProxyState {
                     let auto_config_url = settings.get_string("AutoConfigURL").unwrap_or_default();
                     let auto_detect = settings.get_u32("AutoDetect").unwrap_or(0);
 
-                    parts.push(format!("proxy_enable={}", proxy_enable));
-                    parts.push(format!("proxy_server={}", proxy_server));
-                    parts.push(format!("proxy_override={}", proxy_override));
-                    parts.push(format!("auto_config_url={}", auto_config_url));
-                    parts.push(format!("auto_detect={}", auto_detect));
+                    "ProxyEnable".hash(&mut hasher);
+                    proxy_enable.hash(&mut hasher);
+                    Self::hash_setting(&mut hasher, "ProxyServer", &proxy_server);
+                    Self::hash_setting(&mut hasher, "ProxyOverride", &proxy_override);
+                    Self::hash_setting(&mut hasher, "AutoConfigURL", &auto_config_url);
+                    "AutoDetect".hash(&mut hasher);
+                    auto_detect.hash(&mut hasher);
 
                     has_proxy = has_proxy
                         || (proxy_enable == 1 && !proxy_server.trim().is_empty())
@@ -71,14 +81,10 @@ impl ProxyState {
                         || auto_detect == 1;
                 }
                 Err(_) => {
-                    parts.push("registry_unavailable=1".to_string());
+                    "registry_unavailable".hash(&mut hasher);
                 }
             }
         }
-
-        let raw = parts.join("|");
-        let mut hasher = DefaultHasher::new();
-        raw.hash(&mut hasher);
 
         Self {
             fingerprint: hasher.finish(),
@@ -87,15 +93,13 @@ impl ProxyState {
     }
 }
 
-struct HttpClientState {
-    client: reqwest::Client,
-    proxy_state: ProxyState,
-}
-
 /// Discord API client
 #[derive(Clone)]
 pub struct DiscordApiClient {
-    http: Arc<Mutex<HttpClientState>>,
+    client: Arc<ArcSwap<reqwest::Client>>,
+    proxy_fingerprint: Arc<AtomicU64>,
+    proxy_has_proxy: Arc<AtomicBool>,
+    last_proxy_check_at_ms: Arc<AtomicU64>,
     token: String,
 }
 
@@ -166,56 +170,93 @@ impl DiscordApiClient {
         );
 
         Ok(Self {
-            http: Arc::new(Mutex::new(HttpClientState {
-                client,
-                proxy_state,
-            })),
+            client: Arc::new(ArcSwap::from_pointee(client)),
+            proxy_fingerprint: Arc::new(AtomicU64::new(proxy_state.fingerprint)),
+            proxy_has_proxy: Arc::new(AtomicBool::new(proxy_state.has_proxy)),
+            last_proxy_check_at_ms: Arc::new(AtomicU64::new(Self::now_millis())),
             token,
         })
     }
 
-    fn current_client(&self) -> reqwest::Client {
-        use crate::logger::{log, LogCategory, LogLevel};
-
-        let latest_proxy_state = ProxyState::current();
-        let mut state = self
-            .http
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-
-        if state.proxy_state != latest_proxy_state {
-            let details = format!(
-                "fingerprint={} -> {}, has_proxy={} -> {}",
-                state.proxy_state.fingerprint,
-                latest_proxy_state.fingerprint,
-                state.proxy_state.has_proxy,
-                latest_proxy_state.has_proxy
-            );
-
-            log(
-                LogLevel::Info,
-                LogCategory::Api,
-                "System proxy state changed, rebuilding HTTP client",
-                Some(&details),
-            );
-
-            match Self::build_http_client(&self.token) {
-                Ok(client) => {
-                    state.client = client;
-                    state.proxy_state = latest_proxy_state;
-                }
-                Err(err) => {
-                    log(
-                        LogLevel::Warn,
-                        LogCategory::Api,
-                        "Failed to rebuild HTTP client after proxy change; using previous client",
-                        Some(&err.to_string()),
-                    );
+    fn now_millis() -> u64 {
+        match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+            Ok(duration) => {
+                let millis = duration.as_millis();
+                if millis > u64::MAX as u128 {
+                    u64::MAX
+                } else {
+                    millis as u64
                 }
             }
+            Err(_) => 0,
+        }
+    }
+
+    fn maybe_refresh_client_for_proxy_state(&self) {
+        use crate::logger::{log, LogCategory, LogLevel};
+
+        let now_ms = Self::now_millis();
+        let last_check_ms = self.last_proxy_check_at_ms.load(Ordering::Acquire);
+
+        if now_ms.saturating_sub(last_check_ms) < PROXY_STATE_CHECK_INTERVAL_MS {
+            return;
         }
 
-        state.client.clone()
+        if self
+            .last_proxy_check_at_ms
+            .compare_exchange(last_check_ms, now_ms, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let latest_proxy_state = ProxyState::current();
+        let previous_fingerprint = self.proxy_fingerprint.load(Ordering::Acquire);
+        let previous_has_proxy = self.proxy_has_proxy.load(Ordering::Acquire);
+
+        if latest_proxy_state.fingerprint == previous_fingerprint
+            && latest_proxy_state.has_proxy == previous_has_proxy
+        {
+            return;
+        }
+
+        let details = format!(
+            "fingerprint={} -> {}, has_proxy={} -> {}",
+            previous_fingerprint,
+            latest_proxy_state.fingerprint,
+            previous_has_proxy,
+            latest_proxy_state.has_proxy
+        );
+
+        log(
+            LogLevel::Info,
+            LogCategory::Api,
+            "System proxy state changed, rebuilding HTTP client",
+            Some(&details),
+        );
+
+        match Self::build_http_client(&self.token) {
+            Ok(client) => {
+                self.client.store(Arc::new(client));
+                self.proxy_fingerprint
+                    .store(latest_proxy_state.fingerprint, Ordering::Release);
+                self.proxy_has_proxy
+                    .store(latest_proxy_state.has_proxy, Ordering::Release);
+            }
+            Err(err) => {
+                log(
+                    LogLevel::Warn,
+                    LogCategory::Api,
+                    "Failed to rebuild HTTP client after proxy change; using previous client",
+                    Some(&err.to_string()),
+                );
+            }
+        }
+    }
+
+    fn current_client(&self) -> reqwest::Client {
+        self.maybe_refresh_client_for_proxy_state();
+        self.client.load_full().as_ref().clone()
     }
 
     /// Get the current X-Super-Properties value (dynamically obtained to ensure latest data)

--- a/src-tauri/src/discord_api.rs
+++ b/src-tauri/src/discord_api.rs
@@ -8,7 +8,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const DISCORD_API_BASE: &str = "https://discord.com/api/v9";
 const USER_AGENT_STRING: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) discord/1.0.9219 Chrome/138.0.7204.251 Electron/37.6.0 Safari/537.36";
@@ -99,7 +99,8 @@ pub struct DiscordApiClient {
     client: Arc<ArcSwap<reqwest::Client>>,
     proxy_fingerprint: Arc<AtomicU64>,
     proxy_has_proxy: Arc<AtomicBool>,
-    last_proxy_check_at_ms: Arc<AtomicU64>,
+    created_at: Arc<Instant>,
+    last_proxy_check_elapsed_ms: Arc<AtomicU64>,
     token: String,
 }
 
@@ -169,55 +170,37 @@ impl DiscordApiClient {
             }),
         );
 
+        let created_at = Arc::new(Instant::now());
+
         Ok(Self {
             client: Arc::new(ArcSwap::from_pointee(client)),
             proxy_fingerprint: Arc::new(AtomicU64::new(proxy_state.fingerprint)),
             proxy_has_proxy: Arc::new(AtomicBool::new(proxy_state.has_proxy)),
-            last_proxy_check_at_ms: Arc::new(AtomicU64::new(Self::now_millis())),
+            created_at,
+            last_proxy_check_elapsed_ms: Arc::new(AtomicU64::new(0)),
             token,
         })
     }
 
-    fn now_millis() -> u64 {
-        match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
-            Ok(duration) => {
-                let millis = duration.as_millis();
-                if millis > u64::MAX as u128 {
-                    u64::MAX
-                } else {
-                    millis as u64
-                }
-            }
-            Err(_) => 0,
+    fn elapsed_millis_since_creation(&self) -> u64 {
+        let millis = self.created_at.elapsed().as_millis();
+        if millis > u64::MAX as u128 {
+            u64::MAX
+        } else {
+            millis as u64
         }
     }
 
-    fn maybe_refresh_client_for_proxy_state(&self) {
+    fn apply_proxy_state_if_changed(&self, latest_proxy_state: ProxyState) -> bool {
         use crate::logger::{log, LogCategory, LogLevel};
 
-        let now_ms = Self::now_millis();
-        let last_check_ms = self.last_proxy_check_at_ms.load(Ordering::Acquire);
-
-        if now_ms.saturating_sub(last_check_ms) < PROXY_STATE_CHECK_INTERVAL_MS {
-            return;
-        }
-
-        if self
-            .last_proxy_check_at_ms
-            .compare_exchange(last_check_ms, now_ms, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return;
-        }
-
-        let latest_proxy_state = ProxyState::current();
         let previous_fingerprint = self.proxy_fingerprint.load(Ordering::Acquire);
         let previous_has_proxy = self.proxy_has_proxy.load(Ordering::Acquire);
 
         if latest_proxy_state.fingerprint == previous_fingerprint
             && latest_proxy_state.has_proxy == previous_has_proxy
         {
-            return;
+            return false;
         }
 
         let details = format!(
@@ -242,6 +225,7 @@ impl DiscordApiClient {
                     .store(latest_proxy_state.fingerprint, Ordering::Release);
                 self.proxy_has_proxy
                     .store(latest_proxy_state.has_proxy, Ordering::Release);
+                true
             }
             Err(err) => {
                 log(
@@ -250,8 +234,35 @@ impl DiscordApiClient {
                     "Failed to rebuild HTTP client after proxy change; using previous client",
                     Some(&err.to_string()),
                 );
+                false
             }
         }
+    }
+
+    fn maybe_refresh_client_for_proxy_state_with<F>(&self, now_elapsed_ms: u64, probe: F) -> bool
+    where
+        F: FnOnce() -> ProxyState,
+    {
+        let last_check_ms = self.last_proxy_check_elapsed_ms.load(Ordering::Acquire);
+
+        if now_elapsed_ms.saturating_sub(last_check_ms) < PROXY_STATE_CHECK_INTERVAL_MS {
+            return false;
+        }
+
+        if self
+            .last_proxy_check_elapsed_ms
+            .compare_exchange(last_check_ms, now_elapsed_ms, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return false;
+        }
+
+        self.apply_proxy_state_if_changed(probe())
+    }
+
+    fn maybe_refresh_client_for_proxy_state(&self) {
+        let now_elapsed_ms = self.elapsed_millis_since_creation();
+        let _ = self.maybe_refresh_client_for_proxy_state_with(now_elapsed_ms, ProxyState::current);
     }
 
     fn current_client(&self) -> reqwest::Client {
@@ -692,6 +703,91 @@ fn convert_api_quest_to_quest(quest_json: &serde_json::Value) -> Option<Quest> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    const PROXY_ENV_KEYS: [&str; 8] = [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+    ];
+
+    fn env_snapshot() -> Vec<(String, Option<String>)> {
+        PROXY_ENV_KEYS
+            .iter()
+            .map(|key| ((*key).to_string(), std::env::var(key).ok()))
+            .collect()
+    }
+
+    fn restore_env(snapshot: &[(String, Option<String>)]) {
+        for (key, value) in snapshot {
+            match value {
+                Some(v) => {
+                    unsafe { std::env::set_var(key, v) };
+                }
+                None => {
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn proxy_state_fingerprint_changes_when_env_changes() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let snapshot = env_snapshot();
+
+        unsafe { std::env::set_var("HTTP_PROXY", "http://127.0.0.1:7890") };
+        let state_a = ProxyState::current();
+
+        unsafe { std::env::set_var("HTTP_PROXY", "http://127.0.0.1:7891") };
+        let state_b = ProxyState::current();
+
+        restore_env(&snapshot);
+
+        assert_ne!(state_a.fingerprint, state_b.fingerprint);
+    }
+
+    #[test]
+    fn proxy_refresh_respects_interval_and_rebuilds_on_change() {
+        let client = DiscordApiClient::new("test-token".to_string()).unwrap();
+
+        client
+            .last_proxy_check_elapsed_ms
+            .store(0, Ordering::Release);
+
+        let original_fingerprint = client.proxy_fingerprint.load(Ordering::Acquire);
+        let changed_state = ProxyState {
+            fingerprint: original_fingerprint.wrapping_add(1),
+            has_proxy: !client.proxy_has_proxy.load(Ordering::Acquire),
+        };
+
+        let before_interval_refresh = client.maybe_refresh_client_for_proxy_state_with(
+            PROXY_STATE_CHECK_INTERVAL_MS.saturating_sub(1),
+            || changed_state,
+        );
+        assert!(!before_interval_refresh);
+        assert_eq!(
+            client.proxy_fingerprint.load(Ordering::Acquire),
+            original_fingerprint
+        );
+
+        let after_interval_refresh = client.maybe_refresh_client_for_proxy_state_with(
+            PROXY_STATE_CHECK_INTERVAL_MS,
+            || changed_state,
+        );
+        assert!(after_interval_refresh);
+        assert_eq!(
+            client.proxy_fingerprint.load(Ordering::Acquire),
+            changed_state.fingerprint
+        );
+    }
 
     #[tokio::test]
     #[ignore] // Requires valid token

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -484,6 +484,8 @@ async fn fetch_detectable_games(state: State<'_, AppState>) -> Result<Vec<Detect
     // ── Unauthenticated fallback ──────────────────────────────────────────
     let http = reqwest::Client::builder()
         .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) discord/1.0.9219 Chrome/138.0.7204.251 Electron/37.6.0 Safari/537.36")
+        .connect_timeout(std::time::Duration::from_secs(8))
+        .timeout(std::time::Duration::from_secs(20))
         .build()
         .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
 

--- a/src-tauri/src/token_extractor.rs
+++ b/src-tauri/src/token_extractor.rs
@@ -463,6 +463,7 @@ pub async fn fetch_build_number_from_discord() -> Result<u64> {
     
     let client = reqwest::Client::builder()
         .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+        .connect_timeout(std::time::Duration::from_secs(8))
         .timeout(std::time::Duration::from_secs(10))
         .build()
         .context("Failed to create HTTP client")?;
@@ -586,6 +587,7 @@ pub async fn fetch_discord_client_info() -> Result<DiscordClientInfo> {
 
     let client = reqwest::Client::builder()
         .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+        .connect_timeout(std::time::Duration::from_secs(8))
         .timeout(std::time::Duration::from_secs(10))
         .build()
         .context("Failed to create HTTP client")?;


### PR DESCRIPTION
This pull request enhances proxy detection and HTTP client management for Discord API requests, with a focus on robust system proxy support (especially on Windows), improved client re-initialization, and better timeout handling. The main changes include dynamic detection of system proxy settings, automatic rebuilding of the HTTP client when proxy state changes, and consistent application of connection and request timeouts across the codebase.

**Proxy and HTTP client management improvements:**

* Added a `ProxyState` struct to dynamically detect system proxy settings, including reading Windows registry keys for proxy configuration when running on Windows (`src-tauri/src/discord_api.rs`).
* Introduced logic to automatically rebuild the internal HTTP client if the system proxy settings change, ensuring requests always respect the latest proxy configuration (`src-tauri/src/discord_api.rs`).
* Added the `windows-registry` crate as a dependency to enable reading proxy settings from the Windows registry (`src-tauri/Cargo.toml`).
* Enabled the `system-proxy` feature for the `reqwest` crate to allow native system proxy support (`src-tauri/Cargo.toml`).

**Timeout handling and consistency:**

* Standardized the use of `.connect_timeout` and `.timeout` for all `reqwest::Client` builders throughout the codebase to improve reliability and prevent hanging requests (`src-tauri/src/discord_api.rs`, `src-tauri/src/lib.rs`, `src-tauri/src/token_extractor.rs`) [[1]](diffhunk://#diff-64787bb77348930eed5c9fb254a8bf2b0247fafc7ff73ed6d4e4fc63e65c8b94L55-R220) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR487-R488) [[3]](diffhunk://#diff-f77022d458aef53067aa060a3bac83d3d4129240b30132944469f5307c03deeeR466) [[4]](diffhunk://#diff-f77022d458aef53067aa060a3bac83d3d4129240b30132944469f5307c03deeeR590).Detect system proxy settings (from env vars and Windows registry) and track a ProxyState fingerprint; rebuild the reqwest HTTP client when the proxy configuration changes. Centralize default headers and HTTP client construction, add connect_timeout/timeout values, and log client initialization and proxy-change events. Enable reqwest's system-proxy feature and add windows-registry to Cargo.toml to support Windows registry probing.