### PR TITLE
feat: add Activity quest support via CDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ discord-quest-helper-v*.zip
 *.exe
 *.msi
 *.txt
+/private-scripts/*

--- a/src-tauri/src/cdp_client.rs
+++ b/src-tauri/src/cdp_client.rs
@@ -279,6 +279,25 @@ pub async fn navigate_primary_discord_target(port: u16, url: &str, timeout_secs:
     navigate_target_via_ws(ws_url, url, timeout_secs).await
 }
 
+pub async fn bring_primary_discord_target_to_front(port: u16) -> Result<()> {
+    use crate::logger::{log, LogCategory, LogLevel};
+
+    let target = get_primary_discord_target(port).await?;
+    let ws_url = target
+        .web_socket_debugger_url
+        .as_ref()
+        .context("Target has no WebSocket URL")?;
+
+    log(
+        LogLevel::Debug,
+        LogCategory::TokenExtraction,
+        &format!("bring_primary_discord_target_to_front: target_url={}", target.url),
+        None,
+    );
+
+    bring_target_to_front_via_ws(ws_url, 5).await
+}
+
 pub async fn execute_js_via_primary_discord_target(
     port: u16,
     js_code: &str,
@@ -626,6 +645,29 @@ pub async fn execute_js_via_all_discord_targets(
     Ok(results)
 }
 
+/// Find the activity iframe CDP target (discordsays.com).
+pub async fn find_activity_iframe_target(port: u16) -> Result<CdpTarget> {
+    let targets = get_cdp_targets(port).await?;
+
+    let iframe_target = targets.iter().find(|t| {
+        (t.target_type == "iframe" || t.target_type == "page")
+            && t.url.contains("discordsays.com")
+            && t.web_socket_debugger_url.is_some()
+    });
+
+    iframe_target.cloned().context("No activity iframe target found. Make sure the Activity is launched in Discord.")
+}
+
+/// Execute JavaScript on a specific CDP target via its WebSocket URL.
+pub async fn execute_js_on_target(
+    ws_url: &str,
+    js_code: &str,
+    await_promise: bool,
+    timeout_secs: u64,
+) -> Result<String> {
+    execute_js_via_ws(ws_url, js_code, await_promise, timeout_secs).await
+}
+
 async fn execute_js_via_ws(
     ws_url: &str,
     js_code: &str,
@@ -832,6 +874,57 @@ async fn navigate_target_via_ws(ws_url: &str, url: &str, timeout_secs: u64) -> R
     })
     .await
     .context(format!("CDP page navigation timed out ({}s)", timeout_secs))??;
+
+    let _ = write.close().await;
+
+    Ok(())
+}
+
+async fn bring_target_to_front_via_ws(ws_url: &str, timeout_secs: u64) -> Result<()> {
+    let (ws_stream, _) = connect_async(ws_url)
+        .await
+        .context("Failed to connect to CDP WebSocket")?;
+    let (mut write, mut read) = ws_stream.split();
+
+    let request = serde_json::json!({
+        "id": 1,
+        "method": "Page.bringToFront",
+        "params": {}
+    });
+
+    write
+        .send(Message::Text(request.to_string().into()))
+        .await
+        .context("Failed to send CDP Page.bringToFront request")?;
+
+    tokio::time::timeout(Duration::from_secs(timeout_secs), async {
+        while let Some(msg) = read.next().await {
+            match msg {
+                Ok(Message::Text(text)) => {
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+                        if json.get("id") == Some(&serde_json::json!(1)) {
+                            if let Some(error) = json.get("error") {
+                                let code = error.get("code").and_then(|value| value.as_i64()).unwrap_or(0);
+                                let message = error
+                                    .get("message")
+                                    .and_then(|value| value.as_str())
+                                    .unwrap_or("Unknown CDP error");
+                                return Err(anyhow::anyhow!("CDP error (code {}): {}", code, message));
+                            }
+
+                            return Ok(());
+                        }
+                    }
+                }
+                Ok(_) => continue,
+                Err(e) => return Err(anyhow::anyhow!("WebSocket error: {}", e)),
+            }
+        }
+
+        Err(anyhow::anyhow!("WebSocket closed before Page.bringToFront acknowledgement"))
+    })
+    .await
+    .context(format!("CDP Page.bringToFront timed out ({}s)", timeout_secs))??;
 
     let _ = write.close().await;
 

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -1931,14 +1931,14 @@ fn js_init_activity_quest(quest_id: &str) -> String {
         try {{
             await sdk.commands.questStartTimer({{ quest_id: questId }});
         }} catch(e) {{
-            console.warn("[DQH] questStartTimer failed:", e);
+            return JSON.stringify({{ success: false, error: "questStartTimer failed: " + String(e) }});
         }}
 
         let questInfo = null;
         try {{
             questInfo = await sdk.commands.getQuest();
         }} catch(e) {{
-            console.warn("[DQH] getQuest failed:", e);
+            return JSON.stringify({{ success: false, error: "getQuest failed: " + String(e) }});
         }}
 
         return JSON.stringify({{
@@ -2227,8 +2227,10 @@ pub async fn complete_activity_quest_via_cdp(
         Err(e) => {
             log(LogLevel::Warn, LogCategory::TokenExtraction,
                 &format!("CDP activity quest verification failed: {}", e), None);
-            let _ = app_handle.emit("quest-progress", 100.0f64);
-            let _ = app_handle.emit("quest-complete", ());
+            let _ = app_handle.emit(
+                "quest-error",
+                format!("Activity quest verification failed: {}", e),
+            );
         }
     }
 

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -1889,6 +1889,353 @@ pub async fn complete_video_quest_via_cdp(
     }
 }
 
+/// Generate JS to dispatch an event on the Activity iframe's bridge.
+fn js_dispatch_message_event(event_type: &str, payload_json: &str) -> String {
+    let safe_type = serde_json::to_string(event_type).unwrap_or_else(|_| "\"\"".to_string());
+    let safe_payload = if payload_json.is_empty() {
+        "null".to_string()
+    } else {
+        payload_json.to_string()
+    };
+
+    format!(
+        r#"JSON.stringify((function() {{ try {{ var payload = {payload}; var evt = new MessageEvent("message", {{ data: {{ type: {type}, payload: payload }}, origin: window.location.origin }}); window.dispatchEvent(evt); return {{ success: true, dispatched: {type}, payload: payload }}; }} catch(e) {{ return {{ success: false, error: String(e) }}; }} }})())"#,
+        type = safe_type,
+        payload = safe_payload
+    )
+}
+
+/// Generate JS to call Discord SDK commands inside the activity iframe.
+fn js_init_activity_quest(quest_id: &str) -> String {
+    let safe_quest_id = serde_json::to_string(quest_id).unwrap_or_else(|_| "\"\"".to_string());
+    format!(r#"
+(async () => {{
+    try {{
+        const questId = {safe_quest_id};
+        const sdk = window.discordSDK;
+        if (!sdk || !sdk.commands) {{
+            return JSON.stringify({{ success: false, error: "Discord SDK not found in iframe" }});
+        }}
+
+        try {{
+            await sdk.commands.setActivity({{
+                activity: {{
+                    state: "Playing",
+                    details: "Completing Quest"
+                }}
+            }});
+        }} catch(e) {{
+            console.warn("[DQH] setActivity failed:", e);
+        }}
+
+        try {{
+            await sdk.commands.questStartTimer({{ quest_id: questId }});
+        }} catch(e) {{
+            console.warn("[DQH] questStartTimer failed:", e);
+        }}
+
+        let questInfo = null;
+        try {{
+            questInfo = await sdk.commands.getQuest();
+        }} catch(e) {{
+            console.warn("[DQH] getQuest failed:", e);
+        }}
+
+        return JSON.stringify({{
+            success: true,
+            questId: questId,
+            questInfo: questInfo
+        }});
+    }} catch (e) {{
+        return JSON.stringify({{ success: false, error: String(e) }});
+    }}
+}})()
+"#)
+}
+
+/// Generate JS to check quest completion status inside the activity iframe.
+fn js_check_activity_quest_status() -> String {
+    r#"
+(async () => {
+    try {
+        const sdk = window.discordSDK;
+        if (!sdk || !sdk.commands) {
+            return JSON.stringify({ success: false, error: "Discord SDK not found" });
+        }
+
+        const quest = await sdk.commands.getQuest();
+        if (!quest) {
+            return JSON.stringify({ success: false, error: "No quest data" });
+        }
+
+        return JSON.stringify({
+            success: true,
+            questId: quest.quest_id,
+            enrolledAt: quest.enrolled_at,
+            completedAt: quest.completed_at,
+            completed: !!quest.completed_at
+        });
+    } catch (e) {
+        return JSON.stringify({ success: false, error: String(e) });
+    }
+})()
+"#.to_string()
+}
+
+/// Generate JS to navigate Discord's SPA to a specific path.
+fn js_navigate_spa(target_path: &str) -> String {
+    let safe_path = serde_json::to_string(target_path).unwrap_or_else(|_| "\"\"".to_string());
+    format!(r#"
+(async () => {{
+    try {{
+        const targetPath = {safe_path};
+        const currentPath = () => window.location.pathname + window.location.search + window.location.hash;
+        const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+        if (currentPath() === targetPath) {{
+            return JSON.stringify({{ success: true, method: "already-there" }});
+        }}
+
+        let wpRequire = null;
+        try {{
+            if (typeof webpackChunkdiscord_app !== "undefined") {{
+                wpRequire = webpackChunkdiscord_app.push([[Symbol()], {{}}, r => r]);
+                webpackChunkdiscord_app.pop();
+            }}
+        }} catch (_) {{}}
+
+        function findRouter() {{
+            if (!wpRequire || !wpRequire.c) return null;
+            const seen = new Set();
+            const inspect = value => {{
+                if (!value || (typeof value !== "object" && typeof value !== "function") || seen.has(value)) return null;
+                seen.add(value);
+                if (typeof value.transitionTo === "function" && (
+                    typeof value.replaceWith === "function"
+                    || typeof value.navigate === "function"
+                    || typeof value.back === "function"
+                )) return value;
+                if (value.router && typeof value.router.transitionTo === "function") return value.router;
+                return null;
+            }};
+            for (const m of Object.values(wpRequire.c)) {{
+                try {{
+                    const exp = m?.exports;
+                    if (!exp) continue;
+                    const direct = inspect(exp);
+                    if (direct) return direct;
+                    for (const key of Object.keys(exp)) {{
+                        try {{
+                            const result = inspect(exp[key]);
+                            if (result) return result;
+                        }} catch(e) {{}}
+                    }}
+                }} catch(e) {{}}
+            }}
+            return null;
+        }}
+
+        const router = findRouter();
+        if (router) {{
+            const methods = ["transitionTo", "replaceWith", "navigate"];
+            for (const method of methods) {{
+                if (typeof router[method] === "function") {{
+                    try {{
+                        await Promise.resolve(router[method](targetPath));
+                        await sleep(500);
+                        if (currentPath() === targetPath) {{
+                            return JSON.stringify({{ success: true, method: "router." + method }});
+                        }}
+                    }} catch (e) {{}}
+                }}
+            }}
+        }}
+
+        try {{
+            history.pushState(history.state, "", targetPath);
+            window.dispatchEvent(new PopStateEvent("popstate", {{ state: history.state }}));
+            window.dispatchEvent(new Event("locationchange"));
+            document.dispatchEvent(new Event("locationchange"));
+            await sleep(500);
+            return JSON.stringify({{ success: true, method: "history.pushState" }});
+        }} catch (e) {{
+            return JSON.stringify({{ success: false, error: "All navigation methods failed", details: String(e) }});
+        }}
+    }} catch (e) {{
+        return JSON.stringify({{ success: false, error: String(e) }});
+    }}
+}})()
+"#)
+}
+
+/// Navigate Discord's SPA to a specific path and bring Discord to the front.
+pub async fn navigate_discord_spa(port: u16, target_path: &str) -> Result<()> {
+    use crate::logger::{log, LogCategory, LogLevel};
+
+    let js = js_navigate_spa(target_path);
+    let summary = cdp_execute_json_on_all_targets(port, &js, true, 15, "SPA navigation").await?;
+
+    log_partial_target_failures("SPA navigation", &summary.target_failures);
+
+    let parsed = summary
+        .successful_results
+        .first()
+        .context("SPA navigation returned no successful target results")?;
+
+    let success = parsed.get("success").and_then(|s| s.as_bool()).unwrap_or(false);
+    let method = parsed.get("method").and_then(|m| m.as_str()).unwrap_or("unknown");
+
+    if success {
+        log(LogLevel::Info, LogCategory::TokenExtraction,
+            &format!("Discord SPA navigation successful (method={})", method), None);
+        cdp_client::bring_primary_discord_target_to_front(port)
+            .await
+            .context("Failed to bring Discord window to front after SPA navigation")?;
+        Ok(())
+    } else {
+        let error = parsed.get("error").and_then(|e| e.as_str()).unwrap_or("Unknown error");
+        anyhow::bail!("Discord SPA navigation failed: {} (method={})", error, method)
+    }
+}
+
+/// Complete an ACHIEVEMENT_IN_ACTIVITY quest via CDP.
+pub async fn complete_activity_quest_via_cdp(
+    port: u16,
+    quest_id: String,
+    checkpoint_times: Vec<u32>,
+    app_handle: tauri::AppHandle,
+    mut cancel_rx: tokio::sync::mpsc::Receiver<()>,
+) -> Result<()> {
+    use crate::logger::{log, LogCategory, LogLevel};
+
+    let total_checkpoints = checkpoint_times.len();
+    let total_seconds: u32 = checkpoint_times.iter().sum();
+
+    if total_checkpoints == 0 || total_seconds == 0 {
+        anyhow::bail!("Activity quest requires at least one checkpoint interval");
+    }
+
+    log(LogLevel::Info, LogCategory::TokenExtraction,
+        &format!("CDP activity quest: quest_id={}, checkpoints={}, total={}s, times={:?}",
+            quest_id, total_checkpoints, total_seconds, checkpoint_times), None);
+
+    let iframe_target = cdp_client::find_activity_iframe_target(port).await
+        .context("Failed to find activity iframe target")?;
+
+    let ws_url = iframe_target.web_socket_debugger_url
+        .context("Activity iframe target has no WebSocket URL")?;
+
+    log(LogLevel::Info, LogCategory::TokenExtraction,
+        &format!("CDP activity quest: found iframe target '{}' url='{}'",
+            iframe_target.title, iframe_target.url), None);
+
+    let init_js = js_init_activity_quest(&quest_id);
+    let init_result = cdp_client::execute_js_on_target(&ws_url, &init_js, true, 15).await
+        .context("Failed to initialize activity quest via CDP")?;
+
+    log(LogLevel::Info, LogCategory::TokenExtraction,
+        &format!("CDP activity quest init result: {}", init_result), None);
+
+    let init_parsed: serde_json::Value = serde_json::from_str(&init_result).unwrap_or_default();
+    if init_parsed.get("success") != Some(&serde_json::json!(true)) {
+        let error = init_parsed.get("error")
+            .and_then(|e| e.as_str())
+            .unwrap_or("Unknown init error");
+        anyhow::bail!("Activity quest init failed: {}", error);
+    }
+
+    let _ = app_handle.emit("quest-progress", 0.0f64);
+
+    let mut elapsed_secs = 0u32;
+    for (i, checkpoint_secs) in checkpoint_times.iter().enumerate() {
+        let is_last = i == total_checkpoints - 1;
+        let checkpoint_num = i + 1;
+
+        log(LogLevel::Info, LogCategory::TokenExtraction,
+            &format!("CDP activity quest: waiting for checkpoint {}/{} ({}s)",
+                checkpoint_num, total_checkpoints, checkpoint_secs), None);
+
+        tokio::select! {
+            _ = sleep(Duration::from_secs(*checkpoint_secs as u64)) => {},
+            _ = cancel_rx.recv() => {
+                log(LogLevel::Info, LogCategory::TokenExtraction, "CDP activity quest cancelled", None);
+                let _ = app_handle.emit("quest-stopped", ());
+                return Ok(());
+            }
+        }
+
+        elapsed_secs += checkpoint_secs;
+        let progress_pct = if is_last {
+            100.0
+        } else {
+            ((elapsed_secs as f64) / (total_seconds as f64) * 100.0).min(99.0)
+        };
+        let _ = app_handle.emit("quest-progress", progress_pct);
+
+        if is_last {
+            log(LogLevel::Info, LogCategory::TokenExtraction,
+                "CDP activity quest: dispatching quest-completed event", None);
+
+            let completed_payload = serde_json::json!({
+                "quest_id": quest_id.as_str(),
+                "completed": true
+            }).to_string();
+            let completed_js = js_dispatch_message_event("quest-completed", &completed_payload);
+            match cdp_client::execute_js_on_target(&ws_url, &completed_js, false, 10).await {
+                Ok(result) => log(LogLevel::Info, LogCategory::TokenExtraction,
+                    &format!("CDP activity quest: quest-completed dispatch result: {}", result), None),
+                Err(e) => log(LogLevel::Warn, LogCategory::TokenExtraction,
+                    &format!("CDP activity quest: quest-completed dispatch failed: {}", e), None),
+            }
+        } else {
+            log(LogLevel::Info, LogCategory::TokenExtraction,
+                &format!("CDP activity quest: checkpoint {}/{} reached, dispatching progress step {} (ui={:.1}%)",
+                    checkpoint_num, total_checkpoints, checkpoint_num, progress_pct), None);
+
+            let progress_payload = checkpoint_num.to_string();
+            let progress_js = js_dispatch_message_event("quest-progress", &progress_payload);
+            match cdp_client::execute_js_on_target(&ws_url, &progress_js, false, 10).await {
+                Ok(result) => log(LogLevel::Info, LogCategory::TokenExtraction,
+                    &format!("CDP activity quest: quest-progress dispatch result: {}", result), None),
+                Err(e) => log(LogLevel::Warn, LogCategory::TokenExtraction,
+                    &format!("CDP activity quest: quest-progress dispatch failed: {}", e), None),
+            }
+        }
+    }
+
+    log(LogLevel::Info, LogCategory::TokenExtraction,
+        "CDP activity quest: verifying completion...", None);
+
+    let verify_js = js_check_activity_quest_status();
+    match cdp_client::execute_js_on_target(&ws_url, &verify_js, true, 15).await {
+        Ok(result) => {
+            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap_or_default();
+            let completed = parsed.get("completed").and_then(|c| c.as_bool()).unwrap_or(false);
+            let completed_at = parsed.get("completedAt").and_then(|c| c.as_str()).unwrap_or("null");
+
+            log(LogLevel::Info, LogCategory::TokenExtraction,
+                &format!("CDP activity quest verification: completed={}, completedAt={}", completed, completed_at), None);
+
+            if completed {
+                let _ = app_handle.emit("quest-progress", 100.0f64);
+                let _ = app_handle.emit("quest-complete", ());
+            } else {
+                let _ = app_handle.emit("quest-error",
+                    "Activity quest completed but server has not confirmed. Please check quest status in Discord.".to_string());
+            }
+        }
+        Err(e) => {
+            log(LogLevel::Warn, LogCategory::TokenExtraction,
+                &format!("CDP activity quest verification failed: {}", e), None);
+            let _ = app_handle.emit("quest-progress", 100.0f64);
+            let _ = app_handle.emit("quest-complete", ());
+        }
+    }
+
+    log(LogLevel::Info, LogCategory::TokenExtraction, "CDP activity quest finished", None);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -420,7 +420,9 @@ async fn start_cdp_quest(
                 ).await
             }
             "activity" => {
-                let times = checkpoint_times.unwrap_or_else(|| vec![180, 180, 180]);
+                let times = checkpoint_times
+                    .filter(|v| !v.is_empty())
+                    .unwrap_or_else(|| vec![180, 180, 180]);
                 cdp_quest::complete_activity_quest_via_cdp(
                     cdp_port, quest_id, times,
                     app_handle.clone(), cancel_rx,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -373,6 +373,7 @@ async fn start_cdp_quest(
     seconds_needed: u32,
     initial_progress: f64,
     cdp_port: u16,
+    checkpoint_times: Option<Vec<u32>>,
     state: State<'_, AppState>,
     app_handle: tauri::AppHandle,
 ) -> Result<(), String> {
@@ -418,6 +419,13 @@ async fn start_cdp_quest(
                     app_handle.clone(), cancel_rx,
                 ).await
             }
+            "activity" => {
+                let times = checkpoint_times.unwrap_or_else(|| vec![180, 180, 180]);
+                cdp_quest::complete_activity_quest_via_cdp(
+                    cdp_port, quest_id, times,
+                    app_handle.clone(), cancel_rx,
+                ).await
+            }
             _ => {
                 Err(anyhow::anyhow!("Unknown CDP quest type: {}", quest_type_clone))
             }
@@ -448,6 +456,14 @@ async fn stop_quest_internal(state: &State<'_, AppState>) {
         let _ = quest.cancel_flag.send(()).await;
         println!("Quest stopped");
     }
+}
+
+/// Navigate Discord client SPA to a specific path (no reload)
+#[tauri::command]
+async fn navigate_discord_spa(target_path: String, cdp_port: u16) -> Result<(), String> {
+    cdp_quest::navigate_discord_spa(cdp_port, &target_path)
+        .await
+        .map_err(|e| format!("Failed to navigate Discord SPA: {}", e))
 }
 
 /// Create simulated game
@@ -851,7 +867,8 @@ pub fn run() {
             get_super_properties_mode,
             auto_fetch_super_properties,
             retry_super_properties,
-            capture_discord_headers_cdp
+            capture_discord_headers_cdp,
+            navigate_discord_spa
         ])
         .on_window_event(|_window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {

--- a/src/api/tauri.ts
+++ b/src/api/tauri.ts
@@ -429,12 +429,13 @@ export async function captureDiscordHeadersCdp(port?: number, durationSecs?: num
 
 export async function startCdpQuest(
   questId: string,
-  questType: 'play' | 'stream' | 'video',
+  questType: 'play' | 'stream' | 'video' | 'activity',
   applicationId: string,
   applicationName: string,
   secondsNeeded: number,
   initialProgress: number,
-  cdpPort: number
+  cdpPort: number,
+  checkpointTimes?: number[]
 ): Promise<void> {
   return await invoke('start_cdp_quest', {
     questId,
@@ -443,6 +444,11 @@ export async function startCdpQuest(
     applicationName,
     secondsNeeded,
     initialProgress,
-    cdpPort
+    cdpPort,
+    checkpointTimes: checkpointTimes || []
   })
+}
+
+export async function navigateDiscordSpa(targetPath: string, cdpPort: number): Promise<void> {
+  return await invoke('navigate_discord_spa', { targetPath, cdpPort })
 }

--- a/src/components/QuestCard.vue
+++ b/src/components/QuestCard.vue
@@ -16,7 +16,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Clock, Gift, MonitorPlay, Gamepad2, Activity, Copy, Check } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
-import { firstProgressValue, firstTargetTask, formatDuration } from '@/utils/questTasks'
+import { firstProgressValue, firstTargetTask, formatDuration, getQuestKind } from '@/utils/questTasks'
 import { getQuestRewardViews, type QuestRewardView } from '@/utils/questRewards'
 
 const { t } = useI18n()
@@ -34,6 +34,18 @@ const copiedQuestId = ref(false)
 const isActiveQuest = computed(() => questsStore.activeQuestId === props.quest.id)
 
 const targetDuration = computed(() => {
+  // For active quests, use the store's target duration (includes calculated checkpoint times)
+  if (isActiveQuest.value && questsStore.activeQuestTargetDuration > 0) {
+    return questsStore.activeQuestTargetDuration
+  }
+  // For activity quests that haven't started, estimate based on checkpoint settings
+  const questKind = getQuestKind(props.quest)
+  if (questKind === 'activity') {
+    const task = firstTargetTask(props.quest)
+    const checkpointCount = task?.target || 3
+    const avgCheckpoint = (questsStore.activityCheckpointMin + questsStore.activityCheckpointMax) / 2
+    return Math.round(checkpointCount * avgCheckpoint)
+  }
   return firstTargetTask(props.quest)?.target || 0
 })
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -55,7 +55,21 @@ export default {
         orbs_not_loaded: "Loading...",
         orbs_updated_at: "Updated {time}",
         enrollment_blocked_until: "Quest enrollment is blocked until {time}.",
-        claim_reward: "Claim Reward"
+        claim_reward: "Claim Reward",
+        // Activity quest dialog
+        activity_launch_title: "Launch Activity Quest",
+        activity_launch_desc: "This quest requires launching a Discord Activity. The following steps will be performed:",
+        activity_launch_step1: "Navigate to the quest page in Discord",
+        activity_launch_step2: "Click 'Launch Quest' in Discord to open the Activity",
+        activity_launch_step3: "Complete any authorization prompts in Discord",
+        activity_launch_step4: "Return here and click 'Start Quest' to begin",
+        activity_launch_confirm: "I've launched the Activity in Discord",
+        activity_launch_start: "Start Quest",
+        activity_launch_cancel: "Cancel",
+        activity_launch_navigate: "Open Quest in Discord",
+        activity_launch_navigate_desc: "Click to navigate Discord to this quest page and switch focus to Discord",
+        activity_navigate_error: "Failed to navigate Discord to quest page. Please open Discord manually and go to the Quests page.",
+        activity_cdp_required: "Activity quests require CDP mode. Please enable CDP in Settings."
     },
     quest: {
         progress: "Progress",
@@ -181,6 +195,13 @@ export default {
         tooltip_heartbeat_2: "Video quests support speed multiplier",
         tooltip_heartbeat_3: "No process simulation, but not recommended",
         video_config_cdp_notice: "These settings are not used in CDP mode. CDP mode sends progress directly via Discord's internal API.",
+        // Activity quest settings
+        activity_quest_title: "Activity Quest Configuration",
+        activity_quest_desc: "Configure timing for Activity-type quests. These quests run inside Discord's Activity iframe and require CDP mode.",
+        activity_checkpoint_min: "Checkpoint Interval Min",
+        activity_checkpoint_max: "Checkpoint Interval Max",
+        activity_checkpoint_unit: "seconds",
+        activity_cdp_required: "Activity quests require CDP mode. Enable CDP in the Discord Client Integration section above.",
         debug_unlock_hint: "You are {steps} steps away from being a developer."
     },
     version: {

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -55,7 +55,21 @@ export default {
         orbs_not_loaded: "Cargando...",
         orbs_updated_at: "Actualizado {time}",
         enrollment_blocked_until: "La inscripción en misiones está bloqueada hasta {time}.",
-        claim_reward: "Reclamar recompensa"
+        claim_reward: "Reclamar recompensa",
+        // Activity quest dialog
+        activity_launch_title: "Iniciar misión de Activity",
+        activity_launch_desc: "Esta misión requiere iniciar una Activity de Discord. Se realizarán los siguientes pasos:",
+        activity_launch_step1: "Ir a la página de la misión en Discord",
+        activity_launch_step2: "Haz clic en 'Launch Quest' en Discord para abrir la Activity",
+        activity_launch_step3: "Completa cualquier solicitud de autorización en Discord",
+        activity_launch_step4: "Vuelve aquí y haz clic en 'Iniciar misión' para comenzar",
+        activity_launch_confirm: "Ya inicié la Activity en Discord",
+        activity_launch_start: "Iniciar misión",
+        activity_launch_cancel: "Cancelar",
+        activity_launch_navigate: "Abrir misión en Discord",
+        activity_launch_navigate_desc: "Haz clic para llevar Discord a esta misión y devolver el foco a Discord",
+        activity_navigate_error: "No se pudo navegar a la página de la misión en Discord. Abre Discord manualmente y ve a la página de misiones.",
+        activity_cdp_required: "Las misiones de Activity requieren modo CDP. Activa CDP en Configuración."
     },
     quest: {
         progress: "Progreso",
@@ -180,6 +194,13 @@ export default {
         video_config_cdp_notice: "Estos ajustes no se usan en modo CDP. CDP envía el progreso directamente a través de la API interna de Discord.",
         cdp_banner_connected: "CDP conectado - Las tareas usarán el modo CDP",
         cdp_banner_disconnected: "CDP no conectado - Inicia Discord con flag de depuración",
+        // Activity quest settings
+        activity_quest_title: "Configuración de misiones de Activity",
+        activity_quest_desc: "Configura los tiempos de las misiones de tipo Activity. Estas misiones se ejecutan dentro del iframe de Activity de Discord y requieren modo CDP.",
+        activity_checkpoint_min: "Intervalo mínimo de checkpoint",
+        activity_checkpoint_max: "Intervalo máximo de checkpoint",
+        activity_checkpoint_unit: "segundos",
+        activity_cdp_required: "Las misiones de Activity requieren modo CDP. Activa CDP en la sección de integración del cliente Discord de arriba.",
         debug_unlock_hint: "Estás a {steps} pasos de ser desarrollador."
     },
     version: {

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -55,7 +55,21 @@ export default {
         orbs_not_loaded: "読み込み中...",
         orbs_updated_at: "{time} に更新",
         enrollment_blocked_until: "クエスト登録は {time} までブロックされています。",
-        claim_reward: "報酬を受け取る"
+        claim_reward: "報酬を受け取る",
+        // Activity quest dialog
+        activity_launch_title: "Activity クエストを起動",
+        activity_launch_desc: "このクエストでは Discord Activity の起動が必要です。次の手順を行います：",
+        activity_launch_step1: "Discord のクエストページへ移動",
+        activity_launch_step2: "Discord で 'Launch Quest' をクリックして Activity を開く",
+        activity_launch_step3: "Discord の認可プロンプトを完了",
+        activity_launch_step4: "ここに戻り、「クエスト開始」をクリックして開始",
+        activity_launch_confirm: "Discord で Activity を起動しました",
+        activity_launch_start: "クエスト開始",
+        activity_launch_cancel: "キャンセル",
+        activity_launch_navigate: "Discord でクエストを開く",
+        activity_launch_navigate_desc: "クリックすると Discord をこのクエストページへ移動し、Discord にフォーカスを戻します",
+        activity_navigate_error: "Discord のクエストページへ移動できませんでした。手動で Discord を開き、クエストページへ移動してください。",
+        activity_cdp_required: "Activity クエストには CDP モードが必要です。設定で CDP を有効にしてください。"
     },
     quest: {
         progress: "進捗",
@@ -180,6 +194,13 @@ export default {
         video_config_cdp_notice: "CDP モードではこれらの設定は使用されません。CDP モードは Discord の内部 API を介して進行状況を送信します。",
         cdp_banner_connected: "CDP 接続済み - タスクは CDP モードで実行されます",
         cdp_banner_disconnected: "CDP 未接続 - デバッグフラグで Discord を起動してください",
+        // Activity quest settings
+        activity_quest_title: "Activity クエスト設定",
+        activity_quest_desc: "Activity タイプのクエストのタイミングを設定します。これらのクエストは Discord の Activity iframe 内で実行され、CDP モードが必要です。",
+        activity_checkpoint_min: "チェックポイント最小間隔",
+        activity_checkpoint_max: "チェックポイント最大間隔",
+        activity_checkpoint_unit: "秒",
+        activity_cdp_required: "Activity クエストには CDP モードが必要です。上の Discord クライアント連携セクションで CDP を有効にしてください。",
         debug_unlock_hint: "あと {steps} 回タップで開発者になれます。"
     },
     version: {

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -55,7 +55,21 @@ export default {
         orbs_not_loaded: "로딩 중...",
         orbs_updated_at: "{time} 업데이트",
         enrollment_blocked_until: "퀘스트 등록이 {time}까지 차단되었습니다.",
-        claim_reward: "보상 받기"
+        claim_reward: "보상 받기",
+        // Activity quest dialog
+        activity_launch_title: "Activity 퀘스트 시작",
+        activity_launch_desc: "이 퀘스트는 Discord Activity를 실행해야 합니다. 다음 단계를 진행합니다:",
+        activity_launch_step1: "Discord에서 퀘스트 페이지로 이동",
+        activity_launch_step2: "Discord에서 'Launch Quest'를 클릭하여 Activity 열기",
+        activity_launch_step3: "Discord의 승인 안내를 완료",
+        activity_launch_step4: "여기로 돌아와 '퀘스트 시작'을 클릭하여 시작",
+        activity_launch_confirm: "Discord에서 Activity를 실행했습니다",
+        activity_launch_start: "퀘스트 시작",
+        activity_launch_cancel: "취소",
+        activity_launch_navigate: "Discord에서 퀘스트 열기",
+        activity_launch_navigate_desc: "클릭하면 Discord를 이 퀘스트 페이지로 이동하고 포커스를 Discord로 전환합니다",
+        activity_navigate_error: "Discord의 퀘스트 페이지로 이동하지 못했습니다. Discord를 직접 열고 퀘스트 페이지로 이동하세요.",
+        activity_cdp_required: "Activity 퀘스트에는 CDP 모드가 필요합니다. 설정에서 CDP를 활성화하세요."
     },
     quest: {
         progress: "진행률",
@@ -180,6 +194,13 @@ export default {
         video_config_cdp_notice: "CDP 모드에서는 이 설정이 사용되지 않습니다. CDP 모드는 Discord 내부 API를 통해 진행 상황을 전송합니다.",
         cdp_banner_connected: "CDP 연결됨 - 작업은 CDP 모드로 완료됩니다",
         cdp_banner_disconnected: "CDP 연결 안됨 - 디버그 플래그로 Discord를 시작하세요",
+        // Activity quest settings
+        activity_quest_title: "Activity 퀘스트 구성",
+        activity_quest_desc: "Activity 유형 퀘스트의 타이밍을 구성합니다. 이 퀘스트는 Discord의 Activity iframe 안에서 실행되며 CDP 모드가 필요합니다.",
+        activity_checkpoint_min: "체크포인트 최소 간격",
+        activity_checkpoint_max: "체크포인트 최대 간격",
+        activity_checkpoint_unit: "초",
+        activity_cdp_required: "Activity 퀘스트에는 CDP 모드가 필요합니다. 위의 Discord 클라이언트 통합 섹션에서 CDP를 활성화하세요.",
         debug_unlock_hint: "{steps}번 더 탭하면 개발자가 됩니다."
     },
     version: {

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -55,7 +55,21 @@ export default {
         orbs_not_loaded: "Загрузка...",
         orbs_updated_at: "Обновлено {time}",
         enrollment_blocked_until: "Регистрация на квесты заблокирована до {time}.",
-        claim_reward: "Получить награду"
+        claim_reward: "Получить награду",
+        // Activity quest dialog
+        activity_launch_title: "Запуск Activity-квеста",
+        activity_launch_desc: "Для этого квеста нужно запустить Discord Activity. Будут выполнены следующие шаги:",
+        activity_launch_step1: "Перейти на страницу квеста в Discord",
+        activity_launch_step2: "Нажмите 'Launch Quest' в Discord, чтобы открыть Activity",
+        activity_launch_step3: "Завершите все запросы авторизации в Discord",
+        activity_launch_step4: "Вернитесь сюда и нажмите «Начать квест»",
+        activity_launch_confirm: "Я запустил Activity в Discord",
+        activity_launch_start: "Начать квест",
+        activity_launch_cancel: "Отмена",
+        activity_launch_navigate: "Открыть квест в Discord",
+        activity_launch_navigate_desc: "Нажмите, чтобы открыть страницу этого квеста в Discord и вернуть фокус в Discord",
+        activity_navigate_error: "Не удалось перейти на страницу квеста в Discord. Откройте Discord вручную и перейдите на страницу квестов.",
+        activity_cdp_required: "Для Activity-квестов требуется режим CDP. Включите CDP в настройках."
     },
     quest: {
         progress: "Прогресс",
@@ -180,6 +194,13 @@ export default {
         video_config_cdp_notice: "В режиме CDP эти настройки не используются. CDP отправляет прогресс напрямую через внутренний API Discord.",
         cdp_banner_connected: "CDP подключён — задачи будут выполняться через CDP",
         cdp_banner_disconnected: "CDP не подключён — запустите Discord с флагом отладки",
+        // Activity quest settings
+        activity_quest_title: "Настройки Activity-квестов",
+        activity_quest_desc: "Настройте тайминги для квестов типа Activity. Эти квесты выполняются внутри Activity iframe Discord и требуют режим CDP.",
+        activity_checkpoint_min: "Минимальный интервал checkpoint",
+        activity_checkpoint_max: "Максимальный интервал checkpoint",
+        activity_checkpoint_unit: "секунд",
+        activity_cdp_required: "Для Activity-квестов требуется режим CDP. Включите CDP в разделе интеграции клиента Discord выше.",
         debug_unlock_hint: "Ещё {steps} нажатий до статуса разработчика."
     },
     version: {

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -55,7 +55,21 @@ export default {
         orbs_not_loaded: "載入中...",
         orbs_updated_at: "更新時間 {time}",
         enrollment_blocked_until: "任務註冊已被封鎖至 {time}。",
-        claim_reward: "領取獎勵"
+        claim_reward: "領取獎勵",
+        // Activity quest dialog
+        activity_launch_title: "啟動 Activity 任務",
+        activity_launch_desc: "此任務需要啟動 Discord Activity。將執行以下步驟：",
+        activity_launch_step1: "在 Discord 中前往任務頁面",
+        activity_launch_step2: "在 Discord 中點擊「Launch Quest」開啟 Activity",
+        activity_launch_step3: "完成 Discord 中的授權提示",
+        activity_launch_step4: "返回此處點擊「開始任務」以開始",
+        activity_launch_confirm: "我已在 Discord 中啟動 Activity",
+        activity_launch_start: "開始任務",
+        activity_launch_cancel: "取消",
+        activity_launch_navigate: "在 Discord 中開啟任務",
+        activity_launch_navigate_desc: "點擊後會將 Discord 導航到此任務頁面，並將焦點切回 Discord",
+        activity_navigate_error: "無法將 Discord 導航到任務頁面。請手動開啟 Discord 並前往任務頁面。",
+        activity_cdp_required: "Activity 任務需要 CDP 模式。請在設定中啟用 CDP。"
     },
     quest: {
         progress: "進度",
@@ -180,6 +194,13 @@ export default {
         video_config_cdp_notice: "CDP 模式下這些設定不會生效，CDP 模式透過 Discord 內部 API 直接提交進度。",
         cdp_banner_connected: "CDP 已連接 - 將使用 CDP 模式完成任務",
         cdp_banner_disconnected: "CDP 未連接 - 請使用除錯參數啟動 Discord",
+        // Activity quest settings
+        activity_quest_title: "Activity 任務設定",
+        activity_quest_desc: "設定 Activity 類型任務的檢查點時間間隔。此類任務會在 Discord 的 Activity iframe 中執行，需要 CDP 模式。",
+        activity_checkpoint_min: "檢查點最小間隔",
+        activity_checkpoint_max: "檢查點最大間隔",
+        activity_checkpoint_unit: "秒",
+        activity_cdp_required: "Activity 任務需要 CDP 模式。請在上方的 Discord 用戶端整合區段啟用 CDP。",
         debug_unlock_hint: "再點擊 {steps} 次即可成為開發者。"
     },
     version: {

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -55,7 +55,21 @@ export default {
         orbs_not_loaded: "加载中...",
         orbs_updated_at: "更新时间 {time}",
         enrollment_blocked_until: "任务注册已被封禁至 {time}。",
-        claim_reward: "领取奖励"
+        claim_reward: "领取奖励",
+        // Activity quest dialog
+        activity_launch_title: "启动 Activity 任务",
+        activity_launch_desc: "此任务需要启动 Discord Activity。将执行以下步骤：",
+        activity_launch_step1: "在 Discord 中导航到任务页面",
+        activity_launch_step2: "在 Discord 中点击「Launch Quest」打开 Activity",
+        activity_launch_step3: "完成 Discord 中的授权提示",
+        activity_launch_step4: "返回此处点击「开始任务」确认开始",
+        activity_launch_confirm: "我已在 Discord 中启动了 Activity",
+        activity_launch_start: "开始任务",
+        activity_launch_cancel: "取消",
+        activity_launch_navigate: "在 Discord 中打开任务",
+        activity_launch_navigate_desc: "点击后将 Discord 导航到此任务页面，并将焦点切换到 Discord",
+        activity_navigate_error: "无法将 Discord 导航到任务页面。请手动打开 Discord 并进入任务页面。",
+        activity_cdp_required: "Activity 任务需要 CDP 模式。请在设置中启用 CDP。"
     },
     quest: {
         progress: "进度",
@@ -181,6 +195,13 @@ export default {
         tooltip_heartbeat_2: "视频任务支持倍速完成",
         tooltip_heartbeat_3: "无需进程模拟，但不推荐使用",
         video_config_cdp_notice: "CDP 模式下这些设置不会生效，CDP 模式通过 Discord 内部 API 直接提交进度。",
+        // Activity quest settings
+        activity_quest_title: "Activity 任务配置",
+        activity_quest_desc: "配置 Activity 类型任务的检查点时间间隔。此类任务在 Discord 的 Activity iframe 中运行，需要 CDP 模式。",
+        activity_checkpoint_min: "检查点最小间隔",
+        activity_checkpoint_max: "检查点最大间隔",
+        activity_checkpoint_unit: "秒",
+        activity_cdp_required: "Activity 任务需要 CDP 模式。请在上方的 Discord 客户端集成部分启用 CDP。",
         debug_unlock_hint: "再点击 {steps} 次即可成为开发者。"
     },
     version: {

--- a/src/stores/quests.ts
+++ b/src/stores/quests.ts
@@ -152,20 +152,36 @@ export const useQuestsStore = defineStore('quests', () => {
     }
   })
 
+  function normalizeCheckpoint(value: number, fallback: number, min: number, max: number): number {
+    if (!Number.isFinite(value)) return fallback
+    const n = Math.round(value)
+    return Math.min(max, Math.max(min, n))
+  }
+
   // Persist activity checkpoint interval changes
   watch(activityCheckpointMin, (newMin) => {
-    localStorage.setItem(STORAGE_ACTIVITY_CHECKPOINT_MIN_KEY, String(newMin))
+    const normalizedMin = normalizeCheckpoint(newMin, 180, 30, 600)
+    if (normalizedMin !== newMin) {
+      activityCheckpointMin.value = normalizedMin
+      return
+    }
+    localStorage.setItem(STORAGE_ACTIVITY_CHECKPOINT_MIN_KEY, String(normalizedMin))
     // Ensure max >= min
-    if (activityCheckpointMax.value < newMin) {
-      activityCheckpointMax.value = newMin
+    if (activityCheckpointMax.value < normalizedMin) {
+      activityCheckpointMax.value = normalizedMin
     }
   })
 
   watch(activityCheckpointMax, (newMax) => {
-    localStorage.setItem(STORAGE_ACTIVITY_CHECKPOINT_MAX_KEY, String(newMax))
+    const normalizedMax = normalizeCheckpoint(newMax, 300, 60, 900)
+    if (normalizedMax !== newMax) {
+      activityCheckpointMax.value = normalizedMax
+      return
+    }
+    localStorage.setItem(STORAGE_ACTIVITY_CHECKPOINT_MAX_KEY, String(normalizedMax))
     // Ensure min <= max
-    if (activityCheckpointMin.value > newMax) {
-      activityCheckpointMin.value = newMax
+    if (activityCheckpointMin.value > normalizedMax) {
+      activityCheckpointMin.value = normalizedMax
     }
   })
 
@@ -199,7 +215,7 @@ export const useQuestsStore = defineStore('quests', () => {
       questEnrollmentBlockedUntil.value = response.quest_enrollment_blocked_until || null
       lastQuestsFetchTime.value = Date.now()
     } catch (e) {
-      error.value = e as string
+      error.value = e instanceof Error ? e.message : String(e)
     } finally {
       if (!silent) loading.value = false
     }
@@ -364,7 +380,7 @@ export const useQuestsStore = defineStore('quests', () => {
       startProgressSimulation(gameQuestMode.value === 'cdp' ? 1.0 : speedMultiplier.value)
       setupListeners()
     } catch (e) {
-      error.value = e as string
+      error.value = e instanceof Error ? e.message : String(e)
       throw e
     }
   }
@@ -381,7 +397,7 @@ export const useQuestsStore = defineStore('quests', () => {
       startProgressSimulation(1.0)
       setupListeners()
     } catch (e) {
-      error.value = e as string
+      error.value = e instanceof Error ? e.message : String(e)
       throw e
     }
   }
@@ -498,7 +514,7 @@ export const useQuestsStore = defineStore('quests', () => {
         startPolling()
       }
     } catch (e) {
-      error.value = e as string
+      error.value = e instanceof Error ? e.message : String(e)
       // Clean up if started (only for simulate mode)
       if (activeGameExe.value) {
         try {
@@ -562,7 +578,7 @@ export const useQuestsStore = defineStore('quests', () => {
       setupListeners()
 
     } catch (e) {
-      error.value = e as string
+      error.value = e instanceof Error ? e.message : String(e)
       throw e
     } finally {
       loading.value = false
@@ -765,7 +781,7 @@ export const useQuestsStore = defineStore('quests', () => {
       // Optimistic update
       updateQuestEnrollment(questId, new Date().toISOString())
     } catch (e) {
-      error.value = e as string
+      error.value = e instanceof Error ? e.message : String(e)
       throw e
     }
   }

--- a/src/stores/quests.ts
+++ b/src/stores/quests.ts
@@ -42,7 +42,7 @@ export const useQuestsStore = defineStore('quests', () => {
   const orbsBalanceError = ref<string | null>(null)
 
   const activeQuestId = ref<string | null>(null)
-  const activeQuestType = ref<'video' | 'stream' | 'game' | null>(null)
+  const activeQuestType = ref<'video' | 'stream' | 'game' | 'activity' | null>(null)
   const activeQuestProgress = ref(0)
   const activeQuestTargetDuration = ref(0)
 
@@ -101,6 +101,23 @@ export const useQuestsStore = defineStore('quests', () => {
   const savedShowOrbsBalance = localStorage.getItem(STORAGE_SHOW_ORBS_BALANCE_KEY)
   const showOrbsBalance = ref(savedShowOrbsBalance === null ? true : savedShowOrbsBalance === 'true')
 
+  // Activity quest checkpoint interval (seconds) - min/max time between checkpoints
+  const STORAGE_ACTIVITY_CHECKPOINT_MIN_KEY = 'questHelper_activityCheckpointMin'
+  const savedCheckpointMin = localStorage.getItem(STORAGE_ACTIVITY_CHECKPOINT_MIN_KEY)
+  let initialCheckpointMin = savedCheckpointMin ? parseInt(savedCheckpointMin) : 180
+  if (isNaN(initialCheckpointMin) || initialCheckpointMin < 30 || initialCheckpointMin > 600) {
+    initialCheckpointMin = 180
+  }
+  const activityCheckpointMin = ref(initialCheckpointMin)
+
+  const STORAGE_ACTIVITY_CHECKPOINT_MAX_KEY = 'questHelper_activityCheckpointMax'
+  const savedCheckpointMax = localStorage.getItem(STORAGE_ACTIVITY_CHECKPOINT_MAX_KEY)
+  let initialCheckpointMax = savedCheckpointMax ? parseInt(savedCheckpointMax) : 300
+  if (isNaN(initialCheckpointMax) || initialCheckpointMax < 60 || initialCheckpointMax > 900) {
+    initialCheckpointMax = 300
+  }
+  const activityCheckpointMax = ref(initialCheckpointMax)
+
   // Persist speed changes to localStorage
   watch(speedMultiplier, (newSpeed) => {
     localStorage.setItem(STORAGE_SPEED_KEY, String(newSpeed))
@@ -132,6 +149,23 @@ export const useQuestsStore = defineStore('quests', () => {
       fetchOrbsBalance().catch(err => {
         console.warn('Background Orbs balance fetch failed:', err)
       })
+    }
+  })
+
+  // Persist activity checkpoint interval changes
+  watch(activityCheckpointMin, (newMin) => {
+    localStorage.setItem(STORAGE_ACTIVITY_CHECKPOINT_MIN_KEY, String(newMin))
+    // Ensure max >= min
+    if (activityCheckpointMax.value < newMin) {
+      activityCheckpointMax.value = newMin
+    }
+  })
+
+  watch(activityCheckpointMax, (newMax) => {
+    localStorage.setItem(STORAGE_ACTIVITY_CHECKPOINT_MAX_KEY, String(newMax))
+    // Ensure min <= max
+    if (activityCheckpointMin.value > newMax) {
+      activityCheckpointMin.value = newMax
     }
   })
 
@@ -472,6 +506,63 @@ export const useQuestsStore = defineStore('quests', () => {
         } catch { }
         activeGameExe.value = null
       }
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function startActivity(quest: Quest) {
+    loading.value = true
+    error.value = null
+    try {
+      // Activity quests require CDP mode
+      if (!cdpAvailable.value) {
+        throw new Error('Activity quests require CDP mode. Please start Discord with --remote-debugging-port and enable CDP in Settings.')
+      }
+
+      // Get checkpoint count from task config (default 3)
+      const tasks = quest.config.task_config_v2?.tasks ?? quest.config.task_config?.tasks
+      const activityTask = tasks ? Object.values(tasks).find(t =>
+        t.type?.includes('ACTIVITY') || t.type?.includes('ACHIEVEMENT')
+      ) : null
+      const checkpointCount = activityTask?.target || 3
+
+      // Generate random checkpoint times within [min, max] range
+      const min = activityCheckpointMin.value
+      const max = activityCheckpointMax.value
+      const checkpointTimes: number[] = []
+      for (let i = 0; i < checkpointCount; i++) {
+        checkpointTimes.push(Math.floor(Math.random() * (max - min + 1)) + min)
+      }
+      const totalSeconds = checkpointTimes.reduce((sum, t) => sum + t, 0)
+
+      console.log(`Starting activity quest via CDP: ${checkpointCount} checkpoints, times=[${checkpointTimes.join(', ')}], total=${totalSeconds}s`)
+
+      const appId = quest.config.application?.id || ''
+      const appName = quest.config.application?.name || quest.config.messages?.quest_name || 'Activity'
+
+      await startCdpQuest(
+        quest.id,
+        'activity',
+        appId,
+        appName,
+        totalSeconds,
+        0,
+        cdpPort.value,
+        checkpointTimes
+      )
+
+      activeQuestId.value = quest.id
+      activeQuestType.value = 'activity'
+      activeQuestProgress.value = 0
+      activeQuestTargetDuration.value = totalSeconds
+
+      startProgressSimulation(1.0)
+      setupListeners()
+
+    } catch (e) {
+      error.value = e as string
       throw e
     } finally {
       loading.value = false
@@ -853,6 +944,8 @@ export const useQuestsStore = defineStore('quests', () => {
     orbsBalanceLoading,
     orbsBalanceError,
     showOrbsBalance,
+    activityCheckpointMin,
+    activityCheckpointMax,
     activeQuestId,
     activeQuestType,
     activeQuestProgress,
@@ -874,6 +967,7 @@ export const useQuestsStore = defineStore('quests', () => {
     startVideo,
     startStream,
     startPlay,
+    startActivity,
     stop,
     setSpeedMultiplier,
     acceptQuest: acceptQuestWrapper,

--- a/src/utils/questTasks.ts
+++ b/src/utils/questTasks.ts
@@ -122,5 +122,6 @@ export function firstStartableTask(quest: Quest): QuestTaskView | null {
   return tasks.find(task => isVideoTask(task) && task.target != null && task.target > 0)
     ?? tasks.find(task => isDesktopPlayTask(task) && task.target != null && task.target > 0)
     ?? tasks.find(task => isStreamTask(task) && task.target != null && task.target > 0)
+    ?? tasks.find(task => isActivityTask(task) && task.target != null && task.target > 0)
     ?? null
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -450,6 +450,56 @@
         </DialogFooter>
       </DialogContent>
     </Dialog>
+
+    <!-- Activity Quest Launch Dialog -->
+    <Dialog :open="showActivityLaunchDialog" @update:open="showActivityLaunchDialog = $event">
+      <DialogContent class="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{{ t('home.activity_launch_title') }}</DialogTitle>
+          <DialogDescription>
+            {{ t('home.activity_launch_desc') }}
+          </DialogDescription>
+        </DialogHeader>
+        <div class="space-y-4 py-2">
+          <div class="space-y-3 text-sm">
+            <div class="flex items-start gap-3">
+              <div class="flex-shrink-0 w-6 h-6 rounded-full bg-primary/20 text-primary flex items-center justify-center text-xs font-medium">1</div>
+              <p>{{ t('home.activity_launch_step1') }}</p>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="flex-shrink-0 w-6 h-6 rounded-full bg-primary/20 text-primary flex items-center justify-center text-xs font-medium">2</div>
+              <p>{{ t('home.activity_launch_step2') }}</p>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="flex-shrink-0 w-6 h-6 rounded-full bg-primary/20 text-primary flex items-center justify-center text-xs font-medium">3</div>
+              <p>{{ t('home.activity_launch_step3') }}</p>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="flex-shrink-0 w-6 h-6 rounded-full bg-primary/20 text-primary flex items-center justify-center text-xs font-medium">4</div>
+              <p>{{ t('home.activity_launch_step4') }}</p>
+            </div>
+          </div>
+          <div v-if="activityLaunchError" class="p-3 bg-destructive/10 text-destructive rounded-md text-sm border border-destructive/20">
+            {{ activityLaunchError }}
+          </div>
+        </div>
+        <DialogFooter class="flex gap-2">
+          <Button
+            variant="outline"
+            @click="navigateActivityQuestInDiscord"
+            :disabled="activityNavigatingToDiscord"
+          >
+            <Loader2 v-if="activityNavigatingToDiscord" class="mr-2 h-4 w-4 animate-spin" />
+            <ExternalLink v-else class="mr-2 h-4 w-4" />
+            {{ t('home.activity_launch_navigate') }}
+          </Button>
+          <Button variant="ghost" @click="cancelActivityLaunch">{{ t('home.activity_launch_cancel') }}</Button>
+          <Button @click="confirmActivityLaunch">
+            {{ t('home.activity_launch_start') }}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   </div>
 </template>
 
@@ -462,7 +512,11 @@ import { useVersionStore } from '@/stores/version'
 import QuestCard from '@/components/QuestCard.vue'
 import QuestProgress from '@/components/QuestProgress.vue'
 import type { Quest } from '@/api/tauri'
-import { acceptQuest as acceptQuestApi, claimQuestReward } from '@/api/tauri'
+import {
+  acceptQuest as acceptQuestApi,
+  claimQuestReward,
+  navigateDiscordSpa,
+} from '@/api/tauri'
 import { Button } from '@/components/ui/button'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -553,6 +607,13 @@ const pendingPlayQuest = ref<{ quest: Quest, secondsNeeded: number, initialProgr
 const showCustomExeDialog = ref(false)
 const customExeGameName = ref('')
 const customExeInput = ref('')
+
+// Activity quest launch dialog state
+const showActivityLaunchDialog = ref(false)
+const activityLaunchQuest = ref<Quest | null>(null)
+const activityLaunchError = ref<string | null>(null)
+const activityNavigatingToDiscord = ref(false)
+
 // localStorage key for filters
 const FILTERS_STORAGE_KEY = 'questHelper_filters'
 
@@ -974,8 +1035,16 @@ async function startQuest(quest: Quest) {
     const gameName = quest.config.messages.game_title || quest.config.messages.quest_name
     alert(`Stream quests require you to stream "${gameName}" on Discord.\n\nPlease:\n1. Start a stream in a Discord voice channel\n2. Use "Game Simulator" to simulate running the game\n3. Discord will track your streaming progress`)
   } else if (isActivityQuest) {
-    // Activity quest - needs special handling (Discord Activity)
-    alert('Activity quests require launching a Discord Activity. Please complete in Discord client.')
+    // Activity quest - requires CDP mode
+    if (!questsStore.cdpAvailable) {
+      alert(t('home.activity_cdp_required'))
+      return
+    }
+    // Show the activity launch dialog
+    activityLaunchQuest.value = quest
+    activityLaunchError.value = null
+    showActivityLaunchDialog.value = true
+    return // Wait for user to confirm in dialog
   } else {
     // Unknown type - show warning
     alert(`Unknown quest type: ${taskTypes.join(', ') || 'none'}\n\nPlease check the quest requirements in Discord.`)
@@ -1001,6 +1070,48 @@ async function acceptQuest(quest: Quest) {
   } finally {
     acceptingQuest.value = null
   }
+}
+
+// Activity quest launch dialog handlers
+async function navigateActivityQuestInDiscord() {
+  const quest = activityLaunchQuest.value
+  if (!quest || activityNavigatingToDiscord.value) return
+
+  const questPath = `/quest-home#${encodeURIComponent(quest.id)}`
+  activityLaunchError.value = null
+  activityNavigatingToDiscord.value = true
+
+  try {
+    await navigateDiscordSpa(questPath, questsStore.cdpPort)
+  } catch (error) {
+    console.error('Failed to navigate Discord to quest page:', error)
+    activityLaunchError.value = t('home.activity_navigate_error')
+  } finally {
+    activityNavigatingToDiscord.value = false
+  }
+}
+
+async function confirmActivityLaunch() {
+  const quest = activityLaunchQuest.value
+  if (!quest) return
+
+  showActivityLaunchDialog.value = false
+  startingQuestId.value = quest.id
+  try {
+    await questsStore.startActivity(quest)
+  } catch (e) {
+    alert(`Failed to start activity quest: ${e}`)
+  } finally {
+    startingQuestId.value = null
+    activityLaunchQuest.value = null
+  }
+}
+
+function cancelActivityLaunch() {
+  showActivityLaunchDialog.value = false
+  activityLaunchQuest.value = null
+  activityLaunchError.value = null
+  activityNavigatingToDiscord.value = false
 }
 
 async function claimReward(quest: Quest) {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -423,6 +423,52 @@ async function exportLogs() {
         </CardContent>
       </Card>
 
+      <!-- Activity Quest Configuration -->
+      <Card>
+        <CardHeader>
+          <CardTitle>{{ t('settings.activity_quest_title') }}</CardTitle>
+          <CardDescription>{{ t('settings.activity_quest_desc') }}</CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-4">
+          <!-- CDP required notice -->
+          <div v-if="!questsStore.cdpAvailable" class="flex items-start gap-2.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-500">
+            <AlertTriangle class="w-4 h-4 mt-0.5 shrink-0" />
+            <span>{{ t('settings.activity_cdp_required') }}</span>
+          </div>
+          <div class="grid grid-cols-2 gap-4">
+            <div class="space-y-2">
+              <Label>{{ t('settings.activity_checkpoint_min') }}</Label>
+              <div class="flex items-center gap-2">
+                <Input
+                  type="number"
+                  v-model.number="questsStore.activityCheckpointMin"
+                  min="30"
+                  max="600"
+                  class="w-24"
+                />
+                <span class="text-sm text-muted-foreground">{{ t('settings.activity_checkpoint_unit') }}</span>
+              </div>
+              <p class="text-xs text-muted-foreground">30 - 600</p>
+            </div>
+
+            <div class="space-y-2">
+              <Label>{{ t('settings.activity_checkpoint_max') }}</Label>
+              <div class="flex items-center gap-2">
+                <Input
+                  type="number"
+                  v-model.number="questsStore.activityCheckpointMax"
+                  min="60"
+                  max="900"
+                  class="w-24"
+                />
+                <span class="text-sm text-muted-foreground">{{ t('settings.activity_checkpoint_unit') }}</span>
+              </div>
+              <p class="text-xs text-muted-foreground">60 - 900</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
       <!-- Display Options -->
       <Card>
         <CardHeader>


### PR DESCRIPTION
- Add complete_activity_quest_via_cdp() for ACHIEVEMENT_IN_ACTIVITY quest type with checkpoint-based progress tracking and Discord SDK integration
- Add navigate_discord_spa() and Tauri command for SPA navigation within Discord
- Add CDP helpers: find_activity_iframe_target(), execute_js_on_target(), bring_primary_discord_target_to_front() for Activity iframe interaction
- Add JS generators for Discord SDK commands (setActivity, questStartTimer, getQuest) and MessageEvent dispatch inside Activity iframe
- Extend start_cdp_quest with 'activity' type and checkpoint_times parameter
- Add Activity quest launch dialog in QuestCard with step-by-step instructions
- Add Activity quest settings section in Settings view
- Add i18n strings for Activity quest UI in all 7 locales (en, zh, zh-TW, es, ja, ko, ru)
- Update .gitignore to exclude /private-scripts/