### PR TITLE
feat: Enhance CDP activity quest handling and JS robustness

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,21 +31,21 @@
     "radix-vue": "^1.9.17",
     "tailwind-merge": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
-    "vue": "^3.5.38",
+    "vue": "^3.5.39",
     "vue-i18n": "^11.3.2",
     "vue-router": "^5.0.7"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",
     "@tauri-apps/api": "^2.11.1",
-    "@tauri-apps/cli": "^2.11.3",
+    "@tauri-apps/cli": "^2.11.4",
     "@vitejs/plugin-vue": "^6.0.7",
-    "postcss": "^8.5.15",
+    "postcss": "^8.5.16",
     "tailwindcss": "^4.2.4",
-    "tsx": "^4.22.4",
+    "tsx": "^4.22.5",
     "typescript": "^5.3.0",
-    "vite": "^7.3.5",
-    "vitest": "^4.0.15",
+    "vite": "^7.3.6",
+    "vitest": "^4.1.10",
     "vue-tsc": "^3.2.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.3.5
       '@vueuse/core':
         specifier: ^14.2.1
-        version: 14.2.1(vue@3.5.38(typescript@5.9.3))
+        version: 14.2.1(vue@3.5.39(typescript@5.9.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -28,13 +28,13 @@ importers:
         version: 2.1.1
       lucide-vue-next:
         specifier: ^0.577.0
-        version: 0.577.0(vue@3.5.38(typescript@5.9.3))
+        version: 0.577.0(vue@3.5.39(typescript@5.9.3))
       pinia:
         specifier: ^3.0.4
-        version: 3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))
+        version: 3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))
       radix-vue:
         specifier: ^1.9.17
-        version: 1.9.17(vue@3.5.38(typescript@5.9.3))
+        version: 1.9.17(vue@3.5.39(typescript@5.9.3))
       tailwind-merge:
         specifier: ^3.4.1
         version: 3.4.1
@@ -42,14 +42,14 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.2.4)
       vue:
-        specifier: ^3.5.38
-        version: 3.5.38(typescript@5.9.3)
+        specifier: ^3.5.39
+        version: 3.5.39(typescript@5.9.3)
       vue-i18n:
         specifier: ^11.3.2
-        version: 11.3.2(vue@3.5.38(typescript@5.9.3))
+        version: 11.3.2(vue@3.5.39(typescript@5.9.3))
       vue-router:
         specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
+        version: 5.0.7(@vue/compiler-sfc@3.5.39)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.2.4
@@ -58,29 +58,29 @@ importers:
         specifier: ^2.11.1
         version: 2.11.1
       '@tauri-apps/cli':
-        specifier: ^2.11.3
-        version: 2.11.3
+        specifier: ^2.11.4
+        version: 2.11.4
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
+        version: 6.0.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
       postcss:
-        specifier: ^8.5.15
-        version: 8.5.15
+        specifier: ^8.5.16
+        version: 8.5.16
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
       tsx:
-        specifier: ^4.22.4
-        version: 4.22.4
+        specifier: ^4.22.5
+        version: 4.22.5
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
       vite:
-        specifier: ^7.3.5
-        version: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+        specifier: ^7.3.6
+        version: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0)
       vitest:
-        specifier: ^4.0.15
-        version: 4.1.9(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.2.9
         version: 3.2.9(typescript@5.9.3)
@@ -129,34 +129,16 @@ packages:
     resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -165,34 +147,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -201,22 +165,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -225,22 +177,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -249,22 +189,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -273,22 +201,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -297,22 +213,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -321,34 +225,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -357,22 +243,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -381,23 +255,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
@@ -405,34 +267,16 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -724,74 +568,74 @@ packages:
   '@tauri-apps/api@2.11.1':
     resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
 
-  '@tauri-apps/cli-darwin-arm64@2.11.3':
-    resolution: {integrity: sha512-BxpaM8bsCoXs3wd4WKYhas/G1gs7+r7B+e4WnyRk2GEoVOouJB1hoL6E6YLXZDXbYci6VFdrNnobQwd2uVL4ew==}
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
+    resolution: {integrity: sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tauri-apps/cli-darwin-x64@2.11.3':
-    resolution: {integrity: sha512-DbZYuPB1ZEzcAHYeyCvo3ltzM27+aXwPloCrtexPnmgPgulYJm3TOq6aC4S+wPhSXteddg8zImtNkvx/gQzmwg==}
+  '@tauri-apps/cli-darwin-x64@2.11.4':
+    resolution: {integrity: sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.3':
-    resolution: {integrity: sha512-741NduqBmz1XkdU8yz3OI/kBZtqHbvxo9F9ytIeWYU69/Ba9dcZEbqOU++Dp0G/XU8vAI0TfTywEl+p+BbLvaA==}
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
+    resolution: {integrity: sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.11.3':
-    resolution: {integrity: sha512-RWAXT8pTqIczXcoic+LXlo6uEbAXGB0cgh6Pg7Y9xVnEbzryQ1JHtRGj9SxzrKSemBIDBH6Qc24kK2G69i8ofA==}
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
+    resolution: {integrity: sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-musl@2.11.3':
-    resolution: {integrity: sha512-qomqYS+yAkd0gXMRmhguWXc7RfVN+XKKXaEwbf5QmKURwydLFOTldd6F8/WoZDSsBMrV8dpNxz0YneGLmobiSA==}
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
+    resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.11.3':
-    resolution: {integrity: sha512-jOCXbDqeDj5XcclsOBAaXjtTgwZCVg8zEZ+dbPUCoADOgljFgL0rOkYTc96vUYgOrYEfuHYihWMxIDGaD6GwJw==}
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
+    resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
 
-  '@tauri-apps/cli-linux-x64-gnu@2.11.3':
-    resolution: {integrity: sha512-+u3HO/F3gHwL48t9gWN/urqZvpaEJzBFmTaq5eSIhvy8TOvnhb+LgJr3Q3BG+5JxuBrCUjqtOEz6gMttdJFSBA==}
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
+    resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@tauri-apps/cli-linux-x64-musl@2.11.3':
-    resolution: {integrity: sha512-spr5Jpr6KF/vehkLwJ0YmdGv8QwpWU+uw7J8bgijO0sox6ZCYsSNMbcsQjTqPi4xl+p0woIYpWXgChgHYpAc8g==}
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
+    resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.11.3':
-    resolution: {integrity: sha512-abkoRQih5xBa3vz2spWaex0kP/MzVzVPQHom2f8jnCq46R/luOD6Uy85EMU9/bfzf6ZzdorWJsgO+OMX90Fx2w==}
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
+    resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.11.3':
-    resolution: {integrity: sha512-Vy6AvzFm1G40hg3r+OYDB3jkuu7R4wnMzbQBKuun9v6Cgg8IierpLL7toMzrZKs/8NlG8Sg4x1iLFR52oknyHg==}
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
+    resolution: {integrity: sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@tauri-apps/cli-win32-x64-msvc@2.11.3':
-    resolution: {integrity: sha512-GlciF75GdbseajOyib2aCHwE3BXIqZ1liGKWLFRvCdN5wm8h8hFssEVKQ/6E+2jsMLg9v7LCTb983YFnn0QSww==}
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
+    resolution: {integrity: sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@tauri-apps/cli@2.11.3':
-    resolution: {integrity: sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==}
+  '@tauri-apps/cli@2.11.4':
+    resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -829,11 +673,11 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/expect@4.1.9':
-    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@4.1.9':
-    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -843,20 +687,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.9':
-    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@4.1.9':
-    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@4.1.9':
-    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@4.1.9':
-    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/utils@4.1.9':
-    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -876,17 +720,17 @@ packages:
       vue:
         optional: true
 
-  '@vue/compiler-core@3.5.38':
-    resolution: {integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==}
+  '@vue/compiler-core@3.5.39':
+    resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
 
-  '@vue/compiler-dom@3.5.38':
-    resolution: {integrity: sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==}
+  '@vue/compiler-dom@3.5.39':
+    resolution: {integrity: sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==}
 
-  '@vue/compiler-sfc@3.5.38':
-    resolution: {integrity: sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==}
+  '@vue/compiler-sfc@3.5.39':
+    resolution: {integrity: sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==}
 
-  '@vue/compiler-ssr@3.5.38':
-    resolution: {integrity: sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==}
+  '@vue/compiler-ssr@3.5.39':
+    resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -912,22 +756,22 @@ packages:
   '@vue/language-core@3.2.9':
     resolution: {integrity: sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw==}
 
-  '@vue/reactivity@3.5.38':
-    resolution: {integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==}
+  '@vue/reactivity@3.5.39':
+    resolution: {integrity: sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==}
 
-  '@vue/runtime-core@3.5.38':
-    resolution: {integrity: sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==}
+  '@vue/runtime-core@3.5.39':
+    resolution: {integrity: sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==}
 
-  '@vue/runtime-dom@3.5.38':
-    resolution: {integrity: sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==}
+  '@vue/runtime-dom@3.5.39':
+    resolution: {integrity: sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==}
 
-  '@vue/server-renderer@3.5.38':
-    resolution: {integrity: sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==}
+  '@vue/server-renderer@3.5.39':
+    resolution: {integrity: sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==}
     peerDependencies:
-      vue: 3.5.38
+      vue: 3.5.39
 
-  '@vue/shared@3.5.38':
-    resolution: {integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==}
+  '@vue/shared@3.5.39':
+    resolution: {integrity: sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==}
 
   '@vueuse/core@10.11.1':
     resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
@@ -1024,13 +868,8 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
-    engines: {node: '>=18'}
-    hasBin: true
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -1043,8 +882,8 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   exsolve@1.1.0:
@@ -1220,6 +1059,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pinia@3.0.4:
     resolution: {integrity: sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==}
     peerDependencies:
@@ -1235,8 +1078,8 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   quansync@0.2.11:
@@ -1276,8 +1119,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@4.1.0:
-    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
@@ -1305,10 +1148,6 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -1320,8 +1159,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.22.4:
-    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+  tsx@4.22.5:
+    resolution: {integrity: sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -1341,8 +1180,8 @@ packages:
     resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  vite@7.3.5:
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1381,20 +1220,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.9:
-    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.9
-      '@vitest/browser-preview': 4.1.9
-      '@vitest/browser-webdriverio': 4.1.9
-      '@vitest/coverage-istanbul': 4.1.9
-      '@vitest/coverage-v8': 4.1.9
-      '@vitest/ui': 4.1.9
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1463,8 +1302,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.5.38:
-    resolution: {integrity: sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==}
+  vue@3.5.39:
+    resolution: {integrity: sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -1523,157 +1362,79 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
 
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
   '@esbuild/linux-x64@0.28.1':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-x64@0.28.1':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -1690,11 +1451,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@floating-ui/vue@1.1.9(vue@3.5.38(typescript@5.9.3))':
+  '@floating-ui/vue@1.1.9(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/utils': 0.2.10
-      vue-demi: 0.14.10(vue@3.5.38(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -1893,64 +1654,64 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
-      postcss: 8.5.15
+      postcss: 8.5.16
       tailwindcss: 4.2.4
 
   '@tanstack/virtual-core@3.13.13': {}
 
-  '@tanstack/vue-virtual@3.13.13(vue@3.5.38(typescript@5.9.3))':
+  '@tanstack/vue-virtual@3.13.13(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@tanstack/virtual-core': 3.13.13
-      vue: 3.5.38(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   '@tauri-apps/api@2.11.1': {}
 
-  '@tauri-apps/cli-darwin-arm64@2.11.3':
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-darwin-x64@2.11.3':
+  '@tauri-apps/cli-darwin-x64@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.3':
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.11.3':
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-musl@2.11.3':
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.11.3':
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-gnu@2.11.3':
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-musl@2.11.3':
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.11.3':
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.11.3':
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-win32-x64-msvc@2.11.3':
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
     optional: true
 
-  '@tauri-apps/cli@2.11.3':
+  '@tauri-apps/cli@2.11.4':
     optionalDependencies:
-      '@tauri-apps/cli-darwin-arm64': 2.11.3
-      '@tauri-apps/cli-darwin-x64': 2.11.3
-      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.3
-      '@tauri-apps/cli-linux-arm64-gnu': 2.11.3
-      '@tauri-apps/cli-linux-arm64-musl': 2.11.3
-      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.3
-      '@tauri-apps/cli-linux-x64-gnu': 2.11.3
-      '@tauri-apps/cli-linux-x64-musl': 2.11.3
-      '@tauri-apps/cli-win32-arm64-msvc': 2.11.3
-      '@tauri-apps/cli-win32-ia32-msvc': 2.11.3
-      '@tauri-apps/cli-win32-x64-msvc': 2.11.3
+      '@tauri-apps/cli-darwin-arm64': 2.11.4
+      '@tauri-apps/cli-darwin-x64': 2.11.4
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.4
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.4
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-musl': 2.11.4
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:
@@ -1979,50 +1740,50 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@vitejs/plugin-vue@6.0.7(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
-      vue: 3.5.38(typescript@5.9.3)
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0)
+      vue: 3.5.39(typescript@5.9.3)
 
-  '@vitest/expect@4.1.9':
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.9
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.9':
+  '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.9':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.9':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.9': {}
+  '@vitest/spy@4.1.10': {}
 
-  '@vitest/utils@4.1.9':
+  '@vitest/utils@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
+      '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2038,45 +1799,45 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue-macros/common@3.1.2(vue@3.5.38(typescript@5.9.3))':
+  '@vue-macros/common@3.1.2(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.38
+      '@vue/compiler-sfc': 3.5.39
       ast-kit: 2.2.0
       local-pkg: 1.2.1
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.1
     optionalDependencies:
-      vue: 3.5.38(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
-  '@vue/compiler-core@3.5.38':
+  '@vue/compiler-core@3.5.39':
     dependencies:
       '@babel/parser': 7.29.7
-      '@vue/shared': 3.5.38
+      '@vue/shared': 3.5.39
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.38':
+  '@vue/compiler-dom@3.5.39':
     dependencies:
-      '@vue/compiler-core': 3.5.38
-      '@vue/shared': 3.5.38
+      '@vue/compiler-core': 3.5.39
+      '@vue/shared': 3.5.39
 
-  '@vue/compiler-sfc@3.5.38':
+  '@vue/compiler-sfc@3.5.39':
     dependencies:
       '@babel/parser': 7.29.7
-      '@vue/compiler-core': 3.5.38
-      '@vue/compiler-dom': 3.5.38
-      '@vue/compiler-ssr': 3.5.38
-      '@vue/shared': 3.5.38
+      '@vue/compiler-core': 3.5.39
+      '@vue/compiler-dom': 3.5.39
+      '@vue/compiler-ssr': 3.5.39
+      '@vue/shared': 3.5.39
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.16
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.38':
+  '@vue/compiler-ssr@3.5.39':
     dependencies:
-      '@vue/compiler-dom': 3.5.38
-      '@vue/shared': 3.5.38
+      '@vue/compiler-dom': 3.5.39
+      '@vue/shared': 3.5.39
 
   '@vue/devtools-api@6.6.4': {}
 
@@ -2114,68 +1875,68 @@ snapshots:
   '@vue/language-core@3.2.9':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.38
-      '@vue/shared': 3.5.38
+      '@vue/compiler-dom': 3.5.39
+      '@vue/shared': 3.5.39
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
-  '@vue/reactivity@3.5.38':
+  '@vue/reactivity@3.5.39':
     dependencies:
-      '@vue/shared': 3.5.38
+      '@vue/shared': 3.5.39
 
-  '@vue/runtime-core@3.5.38':
+  '@vue/runtime-core@3.5.39':
     dependencies:
-      '@vue/reactivity': 3.5.38
-      '@vue/shared': 3.5.38
+      '@vue/reactivity': 3.5.39
+      '@vue/shared': 3.5.39
 
-  '@vue/runtime-dom@3.5.38':
+  '@vue/runtime-dom@3.5.39':
     dependencies:
-      '@vue/reactivity': 3.5.38
-      '@vue/runtime-core': 3.5.38
-      '@vue/shared': 3.5.38
+      '@vue/reactivity': 3.5.39
+      '@vue/runtime-core': 3.5.39
+      '@vue/shared': 3.5.39
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.38(vue@3.5.38(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.38
-      '@vue/shared': 3.5.38
-      vue: 3.5.38(typescript@5.9.3)
+      '@vue/compiler-ssr': 3.5.39
+      '@vue/shared': 3.5.39
+      vue: 3.5.39(typescript@5.9.3)
 
-  '@vue/shared@3.5.38': {}
+  '@vue/shared@3.5.39': {}
 
-  '@vueuse/core@10.11.1(vue@3.5.38(typescript@5.9.3))':
+  '@vueuse/core@10.11.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.38(typescript@5.9.3))
-      vue-demi: 0.14.10(vue@3.5.38(typescript@5.9.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.39(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@14.2.1(vue@3.5.38(typescript@5.9.3))':
+  '@vueuse/core@14.2.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.2.1
-      '@vueuse/shared': 14.2.1(vue@3.5.38(typescript@5.9.3))
-      vue: 3.5.38(typescript@5.9.3)
+      '@vueuse/shared': 14.2.1(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
 
   '@vueuse/metadata@10.11.1': {}
 
   '@vueuse/metadata@14.2.1': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.38(typescript@5.9.3))':
+  '@vueuse/shared@10.11.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.38(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@14.2.1(vue@3.5.38(typescript@5.9.3))':
+  '@vueuse/shared@14.2.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      vue: 3.5.38(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   acorn@8.17.0: {}
 
@@ -2234,36 +1995,7 @@ snapshots:
 
   entities@7.0.1: {}
 
-  es-module-lexer@2.1.0: {}
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+  es-module-lexer@2.3.0: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -2300,15 +2032,15 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   exsolve@1.1.0: {}
 
   fast-deep-equal@3.1.3: {}
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   fsevents@2.3.3:
     optional: true
@@ -2380,9 +2112,9 @@ snapshots:
       pkg-types: 2.3.1
       quansync: 0.2.11
 
-  lucide-vue-next@0.577.0(vue@3.5.38(typescript@5.9.3)):
+  lucide-vue-next@0.577.0(vue@3.5.39(typescript@5.9.3)):
     dependencies:
-      vue: 3.5.38(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
   magic-string-ast@1.0.3:
     dependencies:
@@ -2421,10 +2153,12 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)):
+  picomatch@4.0.5: {}
+
+  pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 7.7.9
-      vue: 3.5.38(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2440,7 +2174,7 @@ snapshots:
       exsolve: 1.1.0
       pathe: 2.0.3
 
-  postcss@8.5.15:
+  postcss@8.5.16:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -2448,20 +2182,20 @@ snapshots:
 
   quansync@0.2.11: {}
 
-  radix-vue@1.9.17(vue@3.5.38(typescript@5.9.3)):
+  radix-vue@1.9.17(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       '@floating-ui/dom': 1.7.4
-      '@floating-ui/vue': 1.1.9(vue@3.5.38(typescript@5.9.3))
+      '@floating-ui/vue': 1.1.9(vue@3.5.39(typescript@5.9.3))
       '@internationalized/date': 3.10.1
       '@internationalized/number': 3.6.5
-      '@tanstack/vue-virtual': 3.13.13(vue@3.5.38(typescript@5.9.3))
-      '@vueuse/core': 10.11.1(vue@3.5.38(typescript@5.9.3))
-      '@vueuse/shared': 10.11.1(vue@3.5.38(typescript@5.9.3))
+      '@tanstack/vue-virtual': 3.13.13(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/core': 10.11.1(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.39(typescript@5.9.3))
       aria-hidden: 1.2.6
       defu: 6.1.6
       fast-deep-equal: 3.1.3
       nanoid: 5.1.6
-      vue: 3.5.38(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -2510,7 +2244,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@4.1.0: {}
+  std-env@4.2.0: {}
 
   superjson@2.2.6:
     dependencies:
@@ -2530,21 +2264,16 @@ snapshots:
 
   tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
 
   tslib@2.8.1: {}
 
-  tsx@4.22.4:
+  tsx@4.22.5:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -2565,64 +2294,64 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
-      tsx: 4.22.4
+      tsx: 4.22.5
       yaml: 2.9.0
 
-  vitest@4.1.9(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.10(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw
 
   vscode-uri@3.1.0: {}
 
-  vue-demi@0.14.10(vue@3.5.38(typescript@5.9.3)):
+  vue-demi@0.14.10(vue@3.5.39(typescript@5.9.3)):
     dependencies:
-      vue: 3.5.38(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
-  vue-i18n@11.3.2(vue@3.5.38(typescript@5.9.3)):
+  vue-i18n@11.3.2(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       '@intlify/core-base': 11.3.2
       '@intlify/devtools-types': 11.3.2
       '@intlify/shared': 11.3.2
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.38(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
 
-  vue-router@5.0.7(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3)):
+  vue-router@5.0.7(@vue/compiler-sfc@3.5.39)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0
-      '@vue-macros/common': 3.1.2(vue@3.5.38(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.5.39(typescript@5.9.3))
       '@vue/devtools-api': 8.1.3
       ast-walker-scope: 0.8.3
       chokidar: 5.0.0
@@ -2637,11 +2366,11 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
-      vue: 3.5.38(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
       yaml: 2.9.0
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.38
-      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))
+      '@vue/compiler-sfc': 3.5.39
+      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))
 
   vue-tsc@3.2.9(typescript@5.9.3):
     dependencies:
@@ -2649,13 +2378,13 @@ snapshots:
       '@vue/language-core': 3.2.9
       typescript: 5.9.3
 
-  vue@3.5.38(typescript@5.9.3):
+  vue@3.5.39(typescript@5.9.3):
     dependencies:
-      '@vue/compiler-dom': 3.5.38
-      '@vue/compiler-sfc': 3.5.38
-      '@vue/runtime-dom': 3.5.38
-      '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@5.9.3))
-      '@vue/shared': 3.5.38
+      '@vue/compiler-dom': 3.5.39
+      '@vue/compiler-sfc': 3.5.39
+      '@vue/runtime-dom': 3.5.39
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@5.9.3))
+      '@vue/shared': 3.5.39
     optionalDependencies:
       typescript: 5.9.3
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "app_dirs2"
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -393,9 +393,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -531,18 +531,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -674,9 +674,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbus"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
 dependencies = [
  "libc",
  "libdbus-sys",
@@ -755,7 +755,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -775,7 +775,7 @@ dependencies = [
  "futures-util",
  "once_cell",
  "pbkdf2",
- "rand 0.10.1",
+ "rand 0.10.2",
  "regex",
  "reqwest",
  "security-framework",
@@ -934,9 +934,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "embed-resource"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31a88c8d26de40ed18fe748c547845aa39de1db3afd958f8cb91579f3644bcb"
+checksum = "fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd"
 dependencies = [
  "cc",
  "memchr",
@@ -985,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1721,7 +1721,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2110,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2252,7 +2252,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.17",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2572,14 +2572,13 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.3.5"
+version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
 dependencies = [
  "dunce",
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -2688,12 +2687,6 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
@@ -3113,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.1",
@@ -3360,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3383,7 +3376,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3421,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -3844,7 +3837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4108,9 +4101,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2616f96cb644bf2c5c456d9de4d5d5100e592d7424c74d8b55c5cb96e359e93"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4323,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe41e015bf8fc4d6477ff4926a0ef769dc64ff34c7b0038b6f7cacae892acb5c"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -4380,7 +4373,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.17",
- "toml 1.0.6+spec-1.1.0",
+ "toml 0.9.11+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -4408,7 +4401,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4474,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4494,9 +4487,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4790,7 +4783,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.17",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4943,9 +4936,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
@@ -6047,18 +6040,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/src/cdp_client.rs
+++ b/src-tauri/src/cdp_client.rs
@@ -785,8 +785,7 @@ fn activity_target_application_id(target: &CdpTarget) -> Option<String> {
 
 fn describe_activity_host_for_log(host: &str) -> String {
     if let Some(application_id) = host.strip_suffix(".discordsays.com") {
-        if !application_id.is_empty()
-            && application_id.chars().all(|value| value.is_ascii_digit())
+        if !application_id.is_empty() && application_id.chars().all(|value| value.is_ascii_digit())
         {
             return format!(
                 "{}.discordsays.com",
@@ -806,6 +805,10 @@ fn is_activity_target(target: &CdpTarget) -> bool {
     (target.target_type == "iframe" || target.target_type == "page")
         && is_activity_host
         && target.web_socket_debugger_url.is_some()
+}
+
+fn is_activity_iframe_target(target: &CdpTarget) -> bool {
+    target.target_type == "iframe"
 }
 
 fn describe_activity_targets(targets: &[CdpTarget]) -> String {
@@ -859,31 +862,63 @@ pub async fn find_activity_iframe_target_for_application(
 
     if let Some(app_id) = requested_application_id {
         let app_id_hint = crate::logger::sanitize_user_id(app_id);
-        if let Some(target) = activity_targets
+        let matching_targets = activity_targets
             .iter()
-            .find(|target| activity_target_application_id(target).as_deref() == Some(app_id))
-        {
-            return Ok(target.clone());
-        }
+            .filter(|target| activity_target_application_id(target).as_deref() == Some(app_id))
+            .cloned()
+            .collect::<Vec<_>>();
 
-        if activity_targets.len() == 1 {
-            log(
-                LogLevel::Warn,
-                LogCategory::TokenExtraction,
-                &format!(
-                    "No activity iframe matched application_id_hint={}; falling back to sole activity target: {}",
-                    app_id_hint,
-                    describe_activity_targets(&activity_targets)
-                ),
-                None,
+        if !matching_targets.is_empty() {
+            if let Some(target) = matching_targets
+                .iter()
+                .find(|target| is_activity_iframe_target(target))
+            {
+                return Ok(target.clone());
+            }
+
+            anyhow::bail!(
+                "No iframe activity target matched application_id_hint={}. Found matching activity targets: {}",
+                app_id_hint,
+                describe_activity_targets(&matching_targets)
             );
-            return Ok(activity_targets[0].clone());
         }
 
         anyhow::bail!(
             "No activity iframe target matched application_id_hint={}. Found activity targets: {}",
             app_id_hint,
             describe_activity_targets(&activity_targets)
+        );
+    }
+
+    let iframe_targets = activity_targets
+        .iter()
+        .filter(|target| is_activity_iframe_target(target))
+        .collect::<Vec<_>>();
+
+    if let Some(target) = iframe_targets.first() {
+        if activity_targets.len() > 1 {
+            log(
+                LogLevel::Warn,
+                LogCategory::TokenExtraction,
+                &format!(
+                    "Multiple activity targets found with no application_id_hint; defaulting to first iframe target. activity_targets={}",
+                    describe_activity_targets(&activity_targets)
+                ),
+                None,
+            );
+        }
+        return Ok((*target).clone());
+    }
+
+    if activity_targets.len() > 1 {
+        log(
+            LogLevel::Warn,
+            LogCategory::TokenExtraction,
+            &format!(
+                "Multiple non-iframe activity targets found with no application_id_hint; defaulting to first target. activity_targets={}",
+                describe_activity_targets(&activity_targets)
+            ),
+            None,
         );
     }
 

--- a/src-tauri/src/cdp_client.rs
+++ b/src-tauri/src/cdp_client.rs
@@ -876,8 +876,14 @@ pub async fn find_activity_iframe_target_for_application(
                 return Ok(target.clone());
             }
 
+            // Fall back to any matching activity target (e.g. page type)
+            // since some valid activities load as page targets, not iframes.
+            if let Some(target) = matching_targets.first() {
+                return Ok(target.clone());
+            }
+
             anyhow::bail!(
-                "No iframe activity target matched application_id_hint={}. Found matching activity targets: {}",
+                "No activity target matched application_id_hint={}. Found matching activity targets: {}",
                 app_id_hint,
                 describe_activity_targets(&matching_targets)
             );

--- a/src-tauri/src/cdp_client.rs
+++ b/src-tauri/src/cdp_client.rs
@@ -770,25 +770,124 @@ pub async fn execute_js_via_all_discord_targets(
     Ok(results)
 }
 
+fn activity_target_host(target: &CdpTarget) -> Option<String> {
+    reqwest::Url::parse(&target.url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+}
+
+fn activity_target_application_id(target: &CdpTarget) -> Option<String> {
+    let host = activity_target_host(target)?;
+    host.strip_suffix(".discordsays.com")
+        .filter(|prefix| !prefix.is_empty())
+        .map(str::to_owned)
+}
+
+fn describe_activity_host_for_log(host: &str) -> String {
+    if let Some(application_id) = host.strip_suffix(".discordsays.com") {
+        if !application_id.is_empty()
+            && application_id.chars().all(|value| value.is_ascii_digit())
+        {
+            return format!(
+                "{}.discordsays.com",
+                crate::logger::sanitize_user_id(application_id)
+            );
+        }
+    }
+
+    host.to_string()
+}
+
+fn is_activity_target(target: &CdpTarget) -> bool {
+    let is_activity_host = activity_target_host(target)
+        .map(|host| host == "discordsays.com" || host.ends_with(".discordsays.com"))
+        .unwrap_or(false);
+
+    (target.target_type == "iframe" || target.target_type == "page")
+        && is_activity_host
+        && target.web_socket_debugger_url.is_some()
+}
+
+fn describe_activity_targets(targets: &[CdpTarget]) -> String {
+    if targets.is_empty() {
+        return "none".to_string();
+    }
+
+    targets
+        .iter()
+        .map(|target| {
+            let host = activity_target_host(target).unwrap_or_else(|| "unknown-host".to_string());
+            format!(
+                "{} ({})",
+                describe_activity_host_for_log(&host),
+                target.target_type
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Find the activity iframe CDP target (discordsays.com).
+#[allow(dead_code)]
 pub async fn find_activity_iframe_target(port: u16) -> Result<CdpTarget> {
+    find_activity_iframe_target_for_application(port, None).await
+}
+
+/// Find the activity iframe CDP target for a specific Discord application.
+pub async fn find_activity_iframe_target_for_application(
+    port: u16,
+    application_id: Option<&str>,
+) -> Result<CdpTarget> {
+    use crate::logger::{log, LogCategory, LogLevel};
+
     let targets = get_cdp_targets(port).await?;
 
-    let iframe_target = targets.iter().find(|t| {
-        let is_activity_host = reqwest::Url::parse(&t.url)
-            .ok()
-            .and_then(|url| url.host_str().map(str::to_owned))
-            .map(|host| host == "discordsays.com" || host.ends_with(".discordsays.com"))
-            .unwrap_or(false);
+    let activity_targets = targets
+        .into_iter()
+        .filter(is_activity_target)
+        .collect::<Vec<_>>();
 
-        (t.target_type == "iframe" || t.target_type == "page")
-            && is_activity_host
-            && t.web_socket_debugger_url.is_some()
-    });
+    if activity_targets.is_empty() {
+        anyhow::bail!(
+            "No activity iframe target found. Make sure the Activity is launched in Discord."
+        );
+    }
 
-    iframe_target
-        .cloned()
-        .context("No activity iframe target found. Make sure the Activity is launched in Discord.")
+    let requested_application_id = application_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    if let Some(app_id) = requested_application_id {
+        let app_id_hint = crate::logger::sanitize_user_id(app_id);
+        if let Some(target) = activity_targets
+            .iter()
+            .find(|target| activity_target_application_id(target).as_deref() == Some(app_id))
+        {
+            return Ok(target.clone());
+        }
+
+        if activity_targets.len() == 1 {
+            log(
+                LogLevel::Warn,
+                LogCategory::TokenExtraction,
+                &format!(
+                    "No activity iframe matched application_id_hint={}; falling back to sole activity target: {}",
+                    app_id_hint,
+                    describe_activity_targets(&activity_targets)
+                ),
+                None,
+            );
+            return Ok(activity_targets[0].clone());
+        }
+
+        anyhow::bail!(
+            "No activity iframe target matched application_id_hint={}. Found activity targets: {}",
+            app_id_hint,
+            describe_activity_targets(&activity_targets)
+        );
+    }
+
+    Ok(activity_targets[0].clone())
 }
 
 /// Execute JavaScript on a specific CDP target via its WebSocket URL.

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -2208,13 +2208,11 @@ fn js_dispatch_message_event(event_type: &str, payload_json: &str) -> String {
     )
 }
 
-/// Generate JS to call Discord SDK commands inside the activity iframe.
-fn js_init_activity_quest(quest_id: &str) -> String {
-    let safe_quest_id = serde_json::to_string(quest_id).unwrap_or_else(|_| "\"\"".to_string());
-    r#"
-(async () => {
-    const questId = __DQH_QUEST_ID__;
-    const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const JS_ACTIVITY_HELPERS: &str = r#"
+    const DQH_SDK_WAIT_TIMEOUT_MS = 12000;
+    const DQH_SDK_READY_TIMEOUT_MS = 5000;
+    const DQH_COMMAND_TIMEOUT_MS = 5000;
+    const DQH_QUEST_START_TIMER_TIMEOUT_MS = 10000;
 
     function withTimeout(promise, timeoutMs, label) {
         return new Promise((resolve, reject) => {
@@ -2234,52 +2232,24 @@ fn js_init_activity_quest(quest_id: &str) -> String {
         });
     }
 
-    function stringifyValue(value) {
-        const seen = new WeakSet();
-        try {
-            const json = JSON.stringify(value, (key, val) => {
-                if (typeof val === "bigint") return String(val);
-                if (typeof val === "function") return "[Function " + (val.name || "anonymous") + "]";
-                if (val instanceof Error) {
-                    return {
-                        name: val.name,
-                        message: val.message,
-                        code: val.code,
-                        stack: val.stack
-                    };
-                }
-                if (val && typeof val === "object") {
-                    if (seen.has(val)) return "[Circular]";
-                    seen.add(val);
-                }
-                return val;
-            });
-            if (json === undefined) return String(value);
-            return json.length > 1800 ? json.slice(0, 1800) + "...(truncated)" : json;
-        } catch (jsonError) {
-            try {
-                return String(value);
-            } catch (_) {
-                return "<unprintable value>";
-            }
-        }
+    function sanitizeScalar(value) {
+        return String(value).replace(/\b\d{17,19}\b/g, "[ID]");
     }
 
     function describeError(error) {
         if (error && typeof error === "object") {
             const details = {};
-            for (const key of ["name", "message", "code", "type", "status", "statusCode", "reason", "cmd", "command", "payload"]) {
-                if (error[key] !== undefined) details[key] = error[key];
-            }
-            try {
-                for (const key of Object.keys(error)) {
-                    if (details[key] === undefined) details[key] = error[key];
+            for (const key of ["name", "message", "code", "type", "status", "statusCode", "reason"]) {
+                if (error[key] !== undefined) {
+                    details[key] = typeof error[key] === "string" ? sanitizeScalar(error[key]) : error[key];
                 }
-            } catch (_) {}
-            if (error.stack) details.stack = String(error.stack).split("\n").slice(0, 6).join("\n");
-            return stringifyValue(Object.keys(details).length ? details : error);
+            }
+            const keys = Object.keys(details);
+            if (keys.length > 0) {
+                return JSON.stringify(details);
+            }
         }
-        return String(error);
+        return sanitizeScalar(error);
     }
 
     function commandNames(sdk) {
@@ -2292,11 +2262,28 @@ fn js_init_activity_quest(quest_id: &str) -> String {
         }
     }
 
-    async function waitForSdk(timeoutMs) {
+    function isKnownBenignQuestStartTimerError(value) {
+        return !!value
+            && typeof value === "object"
+            && value.code === 4002
+            && String(value.message || "").includes("Quest not found");
+    }
+"#;
+
+/// Generate JS to call Discord SDK commands inside the activity iframe.
+fn js_init_activity_quest(quest_id: &str) -> String {
+    let safe_quest_id = serde_json::to_string(quest_id).unwrap_or_else(|_| "\"\"".to_string());
+    r#"
+(async () => {
+    const questId = __DQH_QUEST_ID__;
+    const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+__DQH_ACTIVITY_HELPERS__
+
+    async function waitForSdk() {
         const startedAt = Date.now();
         let lastState = "window.discordSDK missing";
 
-        while (Date.now() - startedAt < timeoutMs) {
+        while (Date.now() - startedAt < DQH_SDK_WAIT_TIMEOUT_MS) {
             const sdk = window.discordSDK;
             if (sdk && sdk.commands) {
                 const commands = commandNames(sdk);
@@ -2316,7 +2303,7 @@ fn js_init_activity_quest(quest_id: &str) -> String {
     try {
         let sdkState;
         try {
-            sdkState = await waitForSdk(12000);
+            sdkState = await waitForSdk();
         } catch (e) {
             return JSON.stringify({ success: false, error: describeError(e) });
         }
@@ -2327,7 +2314,7 @@ fn js_init_activity_quest(quest_id: &str) -> String {
 
         if (typeof sdk.ready === "function") {
             try {
-                await withTimeout(sdk.ready(), 5000, "discordSDK.ready");
+                await withTimeout(sdk.ready(), DQH_SDK_READY_TIMEOUT_MS, "discordSDK.ready");
             } catch (e) {
                 return JSON.stringify({
                     success: false,
@@ -2346,7 +2333,7 @@ fn js_init_activity_quest(quest_id: &str) -> String {
                         state: "Playing",
                         details: "Completing Quest"
                     }
-                }), 5000, "setActivity");
+                }), DQH_COMMAND_TIMEOUT_MS, "setActivity");
             }
         } catch(e) {
             setActivityError = describeError(e);
@@ -2357,20 +2344,22 @@ fn js_init_activity_quest(quest_id: &str) -> String {
         let getQuestBeforeError = null;
         if (typeof sdk.commands.getQuest === "function") {
             try {
-                questInfoBefore = await withTimeout(sdk.commands.getQuest(), 5000, "getQuest before start");
+                questInfoBefore = await withTimeout(sdk.commands.getQuest(), DQH_COMMAND_TIMEOUT_MS, "getQuest before start");
                 if (questInfoBefore?.quest_id && String(questInfoBefore.quest_id) !== String(questId)) {
                     return JSON.stringify({
                         success: false,
-                        error: "Activity iframe quest mismatch: iframe quest_id=" + questInfoBefore.quest_id + ", requested quest_id=" + questId,
+                        error: "Activity iframe quest mismatch",
                         commands,
                         waitedMs,
-                        questInfoBefore
+                        questInfoBeforeMatches: false
                     });
                 }
             } catch (e) {
                 getQuestBeforeError = describeError(e);
             }
         }
+        const questInfoBeforeMatches = String(questInfoBefore?.quest_id || "") === String(questId);
+        const questInfoBeforeCompleted = !!questInfoBefore?.completed_at;
 
         let enrollmentStatusBefore = null;
         let enrollmentStatusBeforeError = null;
@@ -2378,20 +2367,19 @@ fn js_init_activity_quest(quest_id: &str) -> String {
             try {
                 enrollmentStatusBefore = await withTimeout(
                     sdk.commands.getQuestEnrollmentStatus({ quest_id: questId }),
-                    5000,
+                    DQH_COMMAND_TIMEOUT_MS,
                     "getQuestEnrollmentStatus before start"
                 );
             } catch (e) {
                 enrollmentStatusBeforeError = describeError(e);
             }
         }
+        const enrollmentStatusBeforeMatches = String(enrollmentStatusBefore?.quest_id || "") === String(questId);
+        const enrollmentStatusBeforeEnrolled =
+            enrollmentStatusBeforeMatches && enrollmentStatusBefore?.is_enrolled === true;
 
         const hasCurrentQuestContext =
-            String(questInfoBefore?.quest_id || "") === String(questId)
-            || (
-                String(enrollmentStatusBefore?.quest_id || "") === String(questId)
-                && enrollmentStatusBefore?.is_enrolled === true
-            );
+            questInfoBeforeMatches || enrollmentStatusBeforeEnrolled;
 
         let startTimerResult = null;
         let startTimerError = null;
@@ -2399,12 +2387,12 @@ fn js_init_activity_quest(quest_id: &str) -> String {
         try {
             startTimerResult = await withTimeout(
                 sdk.commands.questStartTimer({ quest_id: questId }),
-                10000,
+                DQH_QUEST_START_TIMER_TIMEOUT_MS,
                 "questStartTimer"
             );
         } catch(e) {
             startTimerError = describeError(e);
-            if (e?.code === 4002 && hasCurrentQuestContext) {
+            if (isKnownBenignQuestStartTimerError(e) && hasCurrentQuestContext) {
                 startTimerIgnored = true;
                 console.warn("[DQH] questStartTimer returned Quest not found for the current iframe quest; continuing:", e);
             } else {
@@ -2414,29 +2402,33 @@ fn js_init_activity_quest(quest_id: &str) -> String {
                     commands,
                     waitedMs,
                     setActivityError,
-                    questInfoBefore,
                     getQuestBeforeError,
-                    enrollmentStatusBefore,
+                    questInfoBeforeMatches,
+                    questInfoBeforeCompleted,
+                    enrollmentStatusBeforeMatches,
+                    enrollmentStatusBeforeEnrolled,
                     enrollmentStatusBeforeError
                 });
             }
         }
 
         if (startTimerResult && typeof startTimerResult === "object" && startTimerResult.success === false) {
-            if (hasCurrentQuestContext) {
-                startTimerError = stringifyValue(startTimerResult);
+            startTimerError = describeError(startTimerResult);
+            if (isKnownBenignQuestStartTimerError(startTimerResult) && hasCurrentQuestContext) {
                 startTimerIgnored = true;
                 console.warn("[DQH] questStartTimer returned success=false for the current iframe quest; continuing:", startTimerResult);
             } else {
                 return JSON.stringify({
                     success: false,
-                    error: "questStartTimer returned failure: " + stringifyValue(startTimerResult),
+                    error: "questStartTimer returned failure: " + startTimerError,
                     commands,
                     waitedMs,
                     setActivityError,
-                    questInfoBefore,
                     getQuestBeforeError,
-                    enrollmentStatusBefore,
+                    questInfoBeforeMatches,
+                    questInfoBeforeCompleted,
+                    enrollmentStatusBeforeMatches,
+                    enrollmentStatusBeforeEnrolled,
                     enrollmentStatusBeforeError
                 });
             }
@@ -2449,33 +2441,51 @@ fn js_init_activity_quest(quest_id: &str) -> String {
 
         if (typeof sdk.commands.getQuest === "function") {
             try {
-                questInfo = await withTimeout(sdk.commands.getQuest(), 5000, "getQuest after start");
+                questInfo = await withTimeout(sdk.commands.getQuest(), DQH_COMMAND_TIMEOUT_MS, "getQuest after start");
+                if (questInfo?.quest_id && String(questInfo.quest_id) !== String(questId)) {
+                    return JSON.stringify({
+                        success: false,
+                        error: "Activity iframe quest mismatch after start",
+                        commands,
+                        waitedMs,
+                        questInfoAfterMatches: false
+                    });
+                }
             } catch(e) {
                 getQuestAfterError = describeError(e);
             }
         }
+        const questInfoAfterMatches = String(questInfo?.quest_id || "") === String(questId);
+        const questInfoAfterCompleted = !!questInfo?.completed_at;
 
         if (!questInfo && typeof sdk.commands.getQuestEnrollmentStatus === "function") {
             try {
                 enrollmentStatus = await withTimeout(
                     sdk.commands.getQuestEnrollmentStatus({ quest_id: questId }),
-                    5000,
+                    DQH_COMMAND_TIMEOUT_MS,
                     "getQuestEnrollmentStatus"
                 );
             } catch(e) {
                 enrollmentStatusError = describeError(e);
             }
         }
+        const enrollmentStatusMatches = String(enrollmentStatus?.quest_id || "") === String(questId);
+        const enrollmentStatusEnrolled =
+            enrollmentStatusMatches && enrollmentStatus?.is_enrolled === true;
 
         return JSON.stringify({
             success: true,
-            questId: questId,
-            startTimerResult,
-            questInfo,
+            startTimerResultReturned: startTimerResult != null,
+            questInfoBeforeMatches,
+            questInfoBeforeCompleted,
+            questInfoAfterMatches,
+            questInfoAfterCompleted,
             getQuestAfterError,
-            enrollmentStatus,
+            enrollmentStatusMatches,
+            enrollmentStatusEnrolled,
             enrollmentStatusError,
-            enrollmentStatusBefore,
+            enrollmentStatusBeforeMatches,
+            enrollmentStatusBeforeEnrolled,
             enrollmentStatusBeforeError,
             commands,
             waitedMs,
@@ -2489,55 +2499,16 @@ fn js_init_activity_quest(quest_id: &str) -> String {
 })()
 "#
     .replace("__DQH_QUEST_ID__", &safe_quest_id)
+    .replace("__DQH_ACTIVITY_HELPERS__", JS_ACTIVITY_HELPERS)
 }
 
 /// Generate JS to check quest completion status inside the activity iframe.
-fn js_check_activity_quest_status() -> String {
+fn js_check_activity_quest_status(quest_id: &str) -> String {
+    let safe_quest_id = serde_json::to_string(quest_id).unwrap_or_else(|_| "\"\"".to_string());
     r#"
 (async () => {
-    function stringifyValue(value) {
-        const seen = new WeakSet();
-        try {
-            const json = JSON.stringify(value, (key, val) => {
-                if (typeof val === "bigint") return String(val);
-                if (typeof val === "function") return "[Function " + (val.name || "anonymous") + "]";
-                if (val instanceof Error) {
-                    return {
-                        name: val.name,
-                        message: val.message,
-                        code: val.code,
-                        stack: val.stack
-                    };
-                }
-                if (val && typeof val === "object") {
-                    if (seen.has(val)) return "[Circular]";
-                    seen.add(val);
-                }
-                return val;
-            });
-            if (json === undefined) return String(value);
-            return json.length > 1800 ? json.slice(0, 1800) + "...(truncated)" : json;
-        } catch (_) {
-            return String(value);
-        }
-    }
-
-    function describeError(error) {
-        if (error && typeof error === "object") {
-            const details = {};
-            for (const key of ["name", "message", "code", "type", "status", "statusCode", "reason", "cmd", "command", "payload"]) {
-                if (error[key] !== undefined) details[key] = error[key];
-            }
-            try {
-                for (const key of Object.keys(error)) {
-                    if (details[key] === undefined) details[key] = error[key];
-                }
-            } catch (_) {}
-            if (error.stack) details.stack = String(error.stack).split("\n").slice(0, 6).join("\n");
-            return stringifyValue(Object.keys(details).length ? details : error);
-        }
-        return String(error);
-    }
+    const questId = __DQH_QUEST_ID__;
+__DQH_ACTIVITY_HELPERS__
 
     try {
         const sdk = window.discordSDK;
@@ -2551,24 +2522,45 @@ fn js_check_activity_quest_status() -> String {
                 return JSON.stringify({ success: false, error: "No quest data" });
             }
 
+            const questIdMatches = String(quest.quest_id || "") === String(questId);
+            if (!questIdMatches) {
+                return JSON.stringify({
+                    success: false,
+                    error: "Activity quest verification mismatch",
+                    completed: false,
+                    completedAt: null,
+                    questIdMatches
+                });
+            }
+
             return JSON.stringify({
                 success: true,
-                questId: quest.quest_id,
-                enrolledAt: quest.enrolled_at,
                 completedAt: quest.completed_at,
                 completed: !!quest.completed_at,
-                questInfo: quest
+                questIdMatches
             });
         }
 
         if (typeof sdk.commands.getQuestEnrollmentStatus === "function") {
-            const enrollmentStatus = await sdk.commands.getQuestEnrollmentStatus();
+            const enrollmentStatus = await sdk.commands.getQuestEnrollmentStatus({ quest_id: questId });
+            const questIdMatches = String(enrollmentStatus?.quest_id || "") === String(questId);
+            if (!questIdMatches) {
+                return JSON.stringify({
+                    success: false,
+                    error: "Activity quest enrollment verification mismatch",
+                    completed: false,
+                    completedAt: null,
+                    questIdMatches
+                });
+            }
+
             return JSON.stringify({
                 success: true,
                 completed: false,
                 completedAt: null,
                 cannotVerifyCompletion: true,
-                enrollmentStatus
+                questIdMatches,
+                enrolled: enrollmentStatus?.is_enrolled === true
             });
         }
 
@@ -2582,7 +2574,8 @@ fn js_check_activity_quest_status() -> String {
     }
 })()
 "#
-    .to_string()
+    .replace("__DQH_QUEST_ID__", &safe_quest_id)
+    .replace("__DQH_ACTIVITY_HELPERS__", JS_ACTIVITY_HELPERS)
 }
 
 /// Generate JS to navigate Discord's SPA to a specific path.
@@ -2745,13 +2738,17 @@ pub async fn complete_activity_quest_via_cdp(
     port: u16,
     quest_id: String,
     application_id: String,
+    initial_progress: f64,
     checkpoint_times: Vec<u32>,
+    client: Option<crate::discord_api::DiscordApiClient>,
     app_handle: tauri::AppHandle,
     mut cancel_rx: tokio::sync::mpsc::Receiver<()>,
 ) -> Result<()> {
     use crate::logger::{log, sanitize_user_id, LogCategory, LogLevel};
 
-    let total_checkpoints = checkpoint_times.len();
+    let remaining_checkpoints = checkpoint_times.len();
+    let completed_checkpoints = initial_progress.max(0.0).floor() as usize;
+    let total_checkpoints = completed_checkpoints + remaining_checkpoints;
     let total_seconds: u32 = checkpoint_times.iter().sum();
     let quest_id_hint = sanitize_user_id(&quest_id);
     let application_id_hint = if application_id.trim().is_empty() {
@@ -2760,7 +2757,7 @@ pub async fn complete_activity_quest_via_cdp(
         sanitize_user_id(application_id.trim())
     };
 
-    if total_checkpoints == 0 || total_seconds == 0 {
+    if remaining_checkpoints == 0 || total_checkpoints == 0 || total_seconds == 0 {
         anyhow::bail!("Activity quest requires at least one checkpoint interval");
     }
 
@@ -2768,8 +2765,14 @@ pub async fn complete_activity_quest_via_cdp(
         LogLevel::Info,
         LogCategory::TokenExtraction,
         &format!(
-            "CDP activity quest: quest_id_hint={}, application_id_hint={}, checkpoints={}, total={}s, times={:?}",
-            quest_id_hint, application_id_hint, total_checkpoints, total_seconds, checkpoint_times
+            "CDP activity quest: quest_id_hint={}, application_id_hint={}, completed_checkpoints={}, remaining_checkpoints={}, total_checkpoints={}, remaining_total={}s, times={:?}",
+            quest_id_hint,
+            application_id_hint,
+            completed_checkpoints,
+            remaining_checkpoints,
+            total_checkpoints,
+            total_seconds,
+            checkpoint_times
         ),
         None,
     );
@@ -2840,13 +2843,13 @@ pub async fn complete_activity_quest_via_cdp(
         );
     }
 
-    let _ = app_handle.emit("quest-progress", 0.0f64);
+    let initial_pct =
+        ((completed_checkpoints as f64) / (total_checkpoints as f64) * 100.0).clamp(0.0, 99.0);
+    let _ = app_handle.emit("quest-progress", initial_pct);
 
-    let mut elapsed_secs = 0u32;
-    let mut completion_event_dispatched = false;
     for (i, checkpoint_secs) in checkpoint_times.iter().enumerate() {
-        let is_last = i == total_checkpoints - 1;
-        let checkpoint_num = i + 1;
+        let checkpoint_num = completed_checkpoints + i + 1;
+        let is_last = checkpoint_num >= total_checkpoints;
 
         log(
             LogLevel::Info,
@@ -2867,8 +2870,8 @@ pub async fn complete_activity_quest_via_cdp(
             }
         }
 
-        elapsed_secs += checkpoint_secs;
-        let progress_pct = ((elapsed_secs as f64) / (total_seconds as f64) * 100.0).min(99.0);
+        let progress_pct =
+            ((checkpoint_num as f64) / (total_checkpoints as f64) * 100.0).clamp(initial_pct, 99.0);
         let _ = app_handle.emit("quest-progress", progress_pct);
 
         if is_last {
@@ -2886,24 +2889,15 @@ pub async fn complete_activity_quest_via_cdp(
             .to_string();
             let completed_js = js_dispatch_message_event("quest-completed", &completed_payload);
             match cdp_client::execute_js_on_target(&ws_url, &completed_js, false, 10).await {
-                Ok(result) => {
-                    let parsed: serde_json::Value =
-                        serde_json::from_str(&result).unwrap_or_default();
-                    completion_event_dispatched = parsed
-                        .get("success")
-                        .and_then(|value| value.as_bool())
-                        .unwrap_or(false);
-
-                    log(
-                        LogLevel::Info,
-                        LogCategory::TokenExtraction,
-                        &format!(
-                            "CDP activity quest: quest-completed dispatch result: {}",
-                            result
-                        ),
-                        None,
-                    );
-                }
+                Ok(result) => log(
+                    LogLevel::Info,
+                    LogCategory::TokenExtraction,
+                    &format!(
+                        "CDP activity quest: quest-completed dispatch result: {}",
+                        result
+                    ),
+                    None,
+                ),
                 Err(e) => log(
                     LogLevel::Warn,
                     LogCategory::TokenExtraction,
@@ -2945,7 +2939,8 @@ pub async fn complete_activity_quest_via_cdp(
         None,
     );
 
-    let verify_js = js_check_activity_quest_status();
+    let verify_js = js_check_activity_quest_status(&quest_id);
+    let mut verified_completed = false;
     match cdp_client::execute_js_on_target(&ws_url, &verify_js, true, 15).await {
         Ok(result) => {
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap_or_default();
@@ -2969,20 +2964,14 @@ pub async fn complete_activity_quest_via_cdp(
             );
 
             if completed {
-                let _ = app_handle.emit("quest-progress", 100.0f64);
-                let _ = app_handle.emit("quest-complete", ());
-            } else if completion_event_dispatched {
+                verified_completed = true;
+            } else {
                 log(
                     LogLevel::Warn,
                     LogCategory::TokenExtraction,
-                    "CDP activity quest verification did not reflect completion yet, but quest-completed dispatch succeeded; treating quest as complete",
+                    "CDP activity quest iframe verification did not confirm completion; checking server status",
                     None,
                 );
-                let _ = app_handle.emit("quest-progress", 100.0f64);
-                let _ = app_handle.emit("quest-complete", ());
-            } else {
-                let _ = app_handle.emit("quest-error",
-                    "Activity quest completion event was not acknowledged. Please check quest status in Discord.".to_string());
             }
         }
         Err(e) => {
@@ -2992,16 +2981,78 @@ pub async fn complete_activity_quest_via_cdp(
                 &format!("CDP activity quest verification failed: {}", e),
                 None,
             );
-            if completion_event_dispatched {
-                let _ = app_handle.emit("quest-progress", 100.0f64);
-                let _ = app_handle.emit("quest-complete", ());
-            } else {
-                let _ = app_handle.emit(
-                    "quest-error",
-                    format!("Activity quest verification failed: {}", e),
-                );
-            }
         }
+    }
+
+    if !verified_completed {
+        if let Some(api_client) = client.as_ref() {
+            log(
+                LogLevel::Info,
+                LogCategory::TokenExtraction,
+                "CDP activity quest: verifying completion via Discord API...",
+                None,
+            );
+
+            for attempt in 1..=6 {
+                match api_client.get_quest_progress(&quest_id).await {
+                    Ok((progress, completed)) => {
+                        log(
+                            LogLevel::Info,
+                            LogCategory::TokenExtraction,
+                            &format!(
+                                "CDP activity quest API verification attempt {}/6: progress={}, completed={}",
+                                attempt, progress, completed
+                            ),
+                            None,
+                        );
+
+                        if completed {
+                            verified_completed = true;
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        log(
+                            LogLevel::Warn,
+                            LogCategory::TokenExtraction,
+                            &format!(
+                                "CDP activity quest API verification attempt {}/6 failed: {}",
+                                attempt, e
+                            ),
+                            None,
+                        );
+                    }
+                }
+
+                if attempt < 6 {
+                    tokio::select! {
+                        _ = sleep(Duration::from_secs(2)) => {},
+                        _ = cancel_rx.recv() => {
+                            log(LogLevel::Info, LogCategory::TokenExtraction, "CDP activity quest cancelled during final verification", None);
+                            let _ = app_handle.emit("quest-stopped", ());
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        } else {
+            log(
+                LogLevel::Warn,
+                LogCategory::TokenExtraction,
+                "CDP activity quest: no Discord API client available for server-side completion verification",
+                None,
+            );
+        }
+    }
+
+    if verified_completed {
+        let _ = app_handle.emit("quest-progress", 100.0f64);
+        let _ = app_handle.emit("quest-complete", ());
+    } else {
+        let _ = app_handle.emit(
+            "quest-error",
+            "Activity quest finished locally, but Discord has not confirmed completion yet. Refresh quests or check Discord.".to_string(),
+        );
     }
 
     log(

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -2211,77 +2211,374 @@ fn js_dispatch_message_event(event_type: &str, payload_json: &str) -> String {
 /// Generate JS to call Discord SDK commands inside the activity iframe.
 fn js_init_activity_quest(quest_id: &str) -> String {
     let safe_quest_id = serde_json::to_string(quest_id).unwrap_or_else(|_| "\"\"".to_string());
-    format!(
-        r#"
-(async () => {{
-    try {{
-        const questId = {safe_quest_id};
-        const sdk = window.discordSDK;
-        if (!sdk || !sdk.commands) {{
-            return JSON.stringify({{ success: false, error: "Discord SDK not found in iframe" }});
-        }}
+    r#"
+(async () => {
+    const questId = __DQH_QUEST_ID__;
+    const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-        try {{
-            await sdk.commands.setActivity({{
-                activity: {{
-                    state: "Playing",
-                    details: "Completing Quest"
-                }}
-            }});
-        }} catch(e) {{
+    function withTimeout(promise, timeoutMs, label) {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                reject(new Error(label + " timed out after " + timeoutMs + "ms"));
+            }, timeoutMs);
+            Promise.resolve(promise).then(
+                value => {
+                    clearTimeout(timer);
+                    resolve(value);
+                },
+                error => {
+                    clearTimeout(timer);
+                    reject(error);
+                }
+            );
+        });
+    }
+
+    function stringifyValue(value) {
+        const seen = new WeakSet();
+        try {
+            const json = JSON.stringify(value, (key, val) => {
+                if (typeof val === "bigint") return String(val);
+                if (typeof val === "function") return "[Function " + (val.name || "anonymous") + "]";
+                if (val instanceof Error) {
+                    return {
+                        name: val.name,
+                        message: val.message,
+                        code: val.code,
+                        stack: val.stack
+                    };
+                }
+                if (val && typeof val === "object") {
+                    if (seen.has(val)) return "[Circular]";
+                    seen.add(val);
+                }
+                return val;
+            });
+            if (json === undefined) return String(value);
+            return json.length > 1800 ? json.slice(0, 1800) + "...(truncated)" : json;
+        } catch (jsonError) {
+            try {
+                return String(value);
+            } catch (_) {
+                return "<unprintable value>";
+            }
+        }
+    }
+
+    function describeError(error) {
+        if (error && typeof error === "object") {
+            const details = {};
+            for (const key of ["name", "message", "code", "type", "status", "statusCode", "reason", "cmd", "command", "payload"]) {
+                if (error[key] !== undefined) details[key] = error[key];
+            }
+            try {
+                for (const key of Object.keys(error)) {
+                    if (details[key] === undefined) details[key] = error[key];
+                }
+            } catch (_) {}
+            if (error.stack) details.stack = String(error.stack).split("\n").slice(0, 6).join("\n");
+            return stringifyValue(Object.keys(details).length ? details : error);
+        }
+        return String(error);
+    }
+
+    function commandNames(sdk) {
+        try {
+            return Object.keys(sdk?.commands || {})
+                .filter(key => typeof sdk.commands[key] === "function")
+                .sort();
+        } catch (_) {
+            return [];
+        }
+    }
+
+    async function waitForSdk(timeoutMs) {
+        const startedAt = Date.now();
+        let lastState = "window.discordSDK missing";
+
+        while (Date.now() - startedAt < timeoutMs) {
+            const sdk = window.discordSDK;
+            if (sdk && sdk.commands) {
+                const commands = commandNames(sdk);
+                if (typeof sdk.commands.questStartTimer === "function") {
+                    return { sdk, commands, waitedMs: Date.now() - startedAt };
+                }
+                lastState = "questStartTimer missing; commands=[" + commands.join(", ") + "]";
+            } else if (sdk) {
+                lastState = "window.discordSDK present but commands missing";
+            }
+            await sleep(250);
+        }
+
+        throw new Error("Discord SDK not ready: " + lastState);
+    }
+
+    try {
+        let sdkState;
+        try {
+            sdkState = await waitForSdk(12000);
+        } catch (e) {
+            return JSON.stringify({ success: false, error: describeError(e) });
+        }
+
+        const sdk = sdkState.sdk;
+        const commands = sdkState.commands;
+        const waitedMs = sdkState.waitedMs;
+
+        if (typeof sdk.ready === "function") {
+            try {
+                await withTimeout(sdk.ready(), 5000, "discordSDK.ready");
+            } catch (e) {
+                return JSON.stringify({
+                    success: false,
+                    error: "discordSDK.ready failed: " + describeError(e),
+                    commands,
+                    waitedMs
+                });
+            }
+        }
+
+        let setActivityError = null;
+        try {
+            if (typeof sdk.commands.setActivity === "function") {
+                await withTimeout(sdk.commands.setActivity({
+                    activity: {
+                        state: "Playing",
+                        details: "Completing Quest"
+                    }
+                }), 5000, "setActivity");
+            }
+        } catch(e) {
+            setActivityError = describeError(e);
             console.warn("[DQH] setActivity failed:", e);
-        }}
+        }
 
-        try {{
-            await sdk.commands.questStartTimer({{ quest_id: questId }});
-        }} catch(e) {{
-            return JSON.stringify({{ success: false, error: "questStartTimer failed: " + String(e) }});
-        }}
+        let questInfoBefore = null;
+        let getQuestBeforeError = null;
+        if (typeof sdk.commands.getQuest === "function") {
+            try {
+                questInfoBefore = await withTimeout(sdk.commands.getQuest(), 5000, "getQuest before start");
+                if (questInfoBefore?.quest_id && String(questInfoBefore.quest_id) !== String(questId)) {
+                    return JSON.stringify({
+                        success: false,
+                        error: "Activity iframe quest mismatch: iframe quest_id=" + questInfoBefore.quest_id + ", requested quest_id=" + questId,
+                        commands,
+                        waitedMs,
+                        questInfoBefore
+                    });
+                }
+            } catch (e) {
+                getQuestBeforeError = describeError(e);
+            }
+        }
+
+        let enrollmentStatusBefore = null;
+        let enrollmentStatusBeforeError = null;
+        if (typeof sdk.commands.getQuestEnrollmentStatus === "function") {
+            try {
+                enrollmentStatusBefore = await withTimeout(
+                    sdk.commands.getQuestEnrollmentStatus({ quest_id: questId }),
+                    5000,
+                    "getQuestEnrollmentStatus before start"
+                );
+            } catch (e) {
+                enrollmentStatusBeforeError = describeError(e);
+            }
+        }
+
+        const hasCurrentQuestContext =
+            String(questInfoBefore?.quest_id || "") === String(questId)
+            || (
+                String(enrollmentStatusBefore?.quest_id || "") === String(questId)
+                && enrollmentStatusBefore?.is_enrolled === true
+            );
+
+        let startTimerResult = null;
+        let startTimerError = null;
+        let startTimerIgnored = false;
+        try {
+            startTimerResult = await withTimeout(
+                sdk.commands.questStartTimer({ quest_id: questId }),
+                10000,
+                "questStartTimer"
+            );
+        } catch(e) {
+            startTimerError = describeError(e);
+            if (e?.code === 4002 && hasCurrentQuestContext) {
+                startTimerIgnored = true;
+                console.warn("[DQH] questStartTimer returned Quest not found for the current iframe quest; continuing:", e);
+            } else {
+                return JSON.stringify({
+                    success: false,
+                    error: "questStartTimer failed: " + startTimerError,
+                    commands,
+                    waitedMs,
+                    setActivityError,
+                    questInfoBefore,
+                    getQuestBeforeError,
+                    enrollmentStatusBefore,
+                    enrollmentStatusBeforeError
+                });
+            }
+        }
+
+        if (startTimerResult && typeof startTimerResult === "object" && startTimerResult.success === false) {
+            if (hasCurrentQuestContext) {
+                startTimerError = stringifyValue(startTimerResult);
+                startTimerIgnored = true;
+                console.warn("[DQH] questStartTimer returned success=false for the current iframe quest; continuing:", startTimerResult);
+            } else {
+                return JSON.stringify({
+                    success: false,
+                    error: "questStartTimer returned failure: " + stringifyValue(startTimerResult),
+                    commands,
+                    waitedMs,
+                    setActivityError,
+                    questInfoBefore,
+                    getQuestBeforeError,
+                    enrollmentStatusBefore,
+                    enrollmentStatusBeforeError
+                });
+            }
+        }
 
         let questInfo = null;
-        try {{
-            questInfo = await sdk.commands.getQuest();
-        }} catch(e) {{
-            return JSON.stringify({{ success: false, error: "getQuest failed: " + String(e) }});
-        }}
+        let getQuestAfterError = null;
+        let enrollmentStatus = null;
+        let enrollmentStatusError = null;
 
-        return JSON.stringify({{
+        if (typeof sdk.commands.getQuest === "function") {
+            try {
+                questInfo = await withTimeout(sdk.commands.getQuest(), 5000, "getQuest after start");
+            } catch(e) {
+                getQuestAfterError = describeError(e);
+            }
+        }
+
+        if (!questInfo && typeof sdk.commands.getQuestEnrollmentStatus === "function") {
+            try {
+                enrollmentStatus = await withTimeout(
+                    sdk.commands.getQuestEnrollmentStatus({ quest_id: questId }),
+                    5000,
+                    "getQuestEnrollmentStatus"
+                );
+            } catch(e) {
+                enrollmentStatusError = describeError(e);
+            }
+        }
+
+        return JSON.stringify({
             success: true,
             questId: questId,
-            questInfo: questInfo
-        }});
-    }} catch (e) {{
-        return JSON.stringify({{ success: false, error: String(e) }});
-    }}
-}})()
+            startTimerResult,
+            questInfo,
+            getQuestAfterError,
+            enrollmentStatus,
+            enrollmentStatusError,
+            enrollmentStatusBefore,
+            enrollmentStatusBeforeError,
+            commands,
+            waitedMs,
+            setActivityError,
+            startTimerError,
+            startTimerIgnored
+        });
+    } catch (e) {
+        return JSON.stringify({ success: false, error: describeError(e) });
+    }
+})()
 "#
-    )
+    .replace("__DQH_QUEST_ID__", &safe_quest_id)
 }
 
 /// Generate JS to check quest completion status inside the activity iframe.
 fn js_check_activity_quest_status() -> String {
     r#"
 (async () => {
+    function stringifyValue(value) {
+        const seen = new WeakSet();
+        try {
+            const json = JSON.stringify(value, (key, val) => {
+                if (typeof val === "bigint") return String(val);
+                if (typeof val === "function") return "[Function " + (val.name || "anonymous") + "]";
+                if (val instanceof Error) {
+                    return {
+                        name: val.name,
+                        message: val.message,
+                        code: val.code,
+                        stack: val.stack
+                    };
+                }
+                if (val && typeof val === "object") {
+                    if (seen.has(val)) return "[Circular]";
+                    seen.add(val);
+                }
+                return val;
+            });
+            if (json === undefined) return String(value);
+            return json.length > 1800 ? json.slice(0, 1800) + "...(truncated)" : json;
+        } catch (_) {
+            return String(value);
+        }
+    }
+
+    function describeError(error) {
+        if (error && typeof error === "object") {
+            const details = {};
+            for (const key of ["name", "message", "code", "type", "status", "statusCode", "reason", "cmd", "command", "payload"]) {
+                if (error[key] !== undefined) details[key] = error[key];
+            }
+            try {
+                for (const key of Object.keys(error)) {
+                    if (details[key] === undefined) details[key] = error[key];
+                }
+            } catch (_) {}
+            if (error.stack) details.stack = String(error.stack).split("\n").slice(0, 6).join("\n");
+            return stringifyValue(Object.keys(details).length ? details : error);
+        }
+        return String(error);
+    }
+
     try {
         const sdk = window.discordSDK;
         if (!sdk || !sdk.commands) {
             return JSON.stringify({ success: false, error: "Discord SDK not found" });
         }
 
-        const quest = await sdk.commands.getQuest();
-        if (!quest) {
-            return JSON.stringify({ success: false, error: "No quest data" });
+        if (typeof sdk.commands.getQuest === "function") {
+            const quest = await sdk.commands.getQuest();
+            if (!quest) {
+                return JSON.stringify({ success: false, error: "No quest data" });
+            }
+
+            return JSON.stringify({
+                success: true,
+                questId: quest.quest_id,
+                enrolledAt: quest.enrolled_at,
+                completedAt: quest.completed_at,
+                completed: !!quest.completed_at,
+                questInfo: quest
+            });
+        }
+
+        if (typeof sdk.commands.getQuestEnrollmentStatus === "function") {
+            const enrollmentStatus = await sdk.commands.getQuestEnrollmentStatus();
+            return JSON.stringify({
+                success: true,
+                completed: false,
+                completedAt: null,
+                cannotVerifyCompletion: true,
+                enrollmentStatus
+            });
         }
 
         return JSON.stringify({
-            success: true,
-            questId: quest.quest_id,
-            enrolledAt: quest.enrolled_at,
-            completedAt: quest.completed_at,
-            completed: !!quest.completed_at
+            success: false,
+            error: "No SDK command available to verify activity quest completion",
+            commands: Object.keys(sdk.commands || {})
         });
     } catch (e) {
-        return JSON.stringify({ success: false, error: String(e) });
+        return JSON.stringify({ success: false, error: describeError(e) });
     }
 })()
 "#
@@ -2447,14 +2744,21 @@ pub async fn navigate_discord_spa(port: u16, target_path: &str) -> Result<()> {
 pub async fn complete_activity_quest_via_cdp(
     port: u16,
     quest_id: String,
+    application_id: String,
     checkpoint_times: Vec<u32>,
     app_handle: tauri::AppHandle,
     mut cancel_rx: tokio::sync::mpsc::Receiver<()>,
 ) -> Result<()> {
-    use crate::logger::{log, LogCategory, LogLevel};
+    use crate::logger::{log, sanitize_user_id, LogCategory, LogLevel};
 
     let total_checkpoints = checkpoint_times.len();
     let total_seconds: u32 = checkpoint_times.iter().sum();
+    let quest_id_hint = sanitize_user_id(&quest_id);
+    let application_id_hint = if application_id.trim().is_empty() {
+        "none".to_string()
+    } else {
+        sanitize_user_id(application_id.trim())
+    };
 
     if total_checkpoints == 0 || total_seconds == 0 {
         anyhow::bail!("Activity quest requires at least one checkpoint interval");
@@ -2464,15 +2768,22 @@ pub async fn complete_activity_quest_via_cdp(
         LogLevel::Info,
         LogCategory::TokenExtraction,
         &format!(
-            "CDP activity quest: quest_id={}, checkpoints={}, total={}s, times={:?}",
-            quest_id, total_checkpoints, total_seconds, checkpoint_times
+            "CDP activity quest: quest_id_hint={}, application_id_hint={}, checkpoints={}, total={}s, times={:?}",
+            quest_id_hint, application_id_hint, total_checkpoints, total_seconds, checkpoint_times
         ),
         None,
     );
 
-    let iframe_target = cdp_client::find_activity_iframe_target(port)
-        .await
-        .context("Failed to find activity iframe target")?;
+    let application_id_filter = if application_id.trim().is_empty() {
+        None
+    } else {
+        Some(application_id.trim())
+    };
+
+    let iframe_target =
+        cdp_client::find_activity_iframe_target_for_application(port, application_id_filter)
+            .await
+            .context("Failed to find activity iframe target")?;
 
     let ws_url = iframe_target
         .web_socket_debugger_url
@@ -2509,9 +2820,30 @@ pub async fn complete_activity_quest_via_cdp(
         anyhow::bail!("Activity quest init failed: {}", error);
     }
 
+    if init_parsed
+        .get("startTimerIgnored")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+    {
+        let start_timer_error = init_parsed
+            .get("startTimerError")
+            .and_then(|value| value.as_str())
+            .unwrap_or("unknown");
+        log(
+            LogLevel::Warn,
+            LogCategory::TokenExtraction,
+            &format!(
+                "CDP activity quest: questStartTimer was rejected but getQuest confirmed the current iframe quest; continuing with checkpoints (error={})",
+                start_timer_error
+            ),
+            None,
+        );
+    }
+
     let _ = app_handle.emit("quest-progress", 0.0f64);
 
     let mut elapsed_secs = 0u32;
+    let mut completion_event_dispatched = false;
     for (i, checkpoint_secs) in checkpoint_times.iter().enumerate() {
         let is_last = i == total_checkpoints - 1;
         let checkpoint_num = i + 1;
@@ -2536,8 +2868,7 @@ pub async fn complete_activity_quest_via_cdp(
         }
 
         elapsed_secs += checkpoint_secs;
-        let progress_pct =
-            ((elapsed_secs as f64) / (total_seconds as f64) * 100.0).min(99.0);
+        let progress_pct = ((elapsed_secs as f64) / (total_seconds as f64) * 100.0).min(99.0);
         let _ = app_handle.emit("quest-progress", progress_pct);
 
         if is_last {
@@ -2555,15 +2886,24 @@ pub async fn complete_activity_quest_via_cdp(
             .to_string();
             let completed_js = js_dispatch_message_event("quest-completed", &completed_payload);
             match cdp_client::execute_js_on_target(&ws_url, &completed_js, false, 10).await {
-                Ok(result) => log(
-                    LogLevel::Info,
-                    LogCategory::TokenExtraction,
-                    &format!(
-                        "CDP activity quest: quest-completed dispatch result: {}",
-                        result
-                    ),
-                    None,
-                ),
+                Ok(result) => {
+                    let parsed: serde_json::Value =
+                        serde_json::from_str(&result).unwrap_or_default();
+                    completion_event_dispatched = parsed
+                        .get("success")
+                        .and_then(|value| value.as_bool())
+                        .unwrap_or(false);
+
+                    log(
+                        LogLevel::Info,
+                        LogCategory::TokenExtraction,
+                        &format!(
+                            "CDP activity quest: quest-completed dispatch result: {}",
+                            result
+                        ),
+                        None,
+                    );
+                }
                 Err(e) => log(
                     LogLevel::Warn,
                     LogCategory::TokenExtraction,
@@ -2631,9 +2971,18 @@ pub async fn complete_activity_quest_via_cdp(
             if completed {
                 let _ = app_handle.emit("quest-progress", 100.0f64);
                 let _ = app_handle.emit("quest-complete", ());
+            } else if completion_event_dispatched {
+                log(
+                    LogLevel::Warn,
+                    LogCategory::TokenExtraction,
+                    "CDP activity quest verification did not reflect completion yet, but quest-completed dispatch succeeded; treating quest as complete",
+                    None,
+                );
+                let _ = app_handle.emit("quest-progress", 100.0f64);
+                let _ = app_handle.emit("quest-complete", ());
             } else {
                 let _ = app_handle.emit("quest-error",
-                    "Activity quest completed but server has not confirmed. Please check quest status in Discord.".to_string());
+                    "Activity quest completion event was not acknowledged. Please check quest status in Discord.".to_string());
             }
         }
         Err(e) => {
@@ -2643,10 +2992,15 @@ pub async fn complete_activity_quest_via_cdp(
                 &format!("CDP activity quest verification failed: {}", e),
                 None,
             );
-            let _ = app_handle.emit(
-                "quest-error",
-                format!("Activity quest verification failed: {}", e),
-            );
+            if completion_event_dispatched {
+                let _ = app_handle.emit("quest-progress", 100.0f64);
+                let _ = app_handle.emit("quest-complete", ());
+            } else {
+                let _ = app_handle.emit(
+                    "quest-error",
+                    format!("Activity quest verification failed: {}", e),
+                );
+            }
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -527,6 +527,7 @@ async fn start_cdp_quest(
                 cdp_quest::complete_activity_quest_via_cdp(
                     cdp_port,
                     quest_id,
+                    application_id,
                     times,
                     app_handle.clone(),
                     cancel_rx,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -528,7 +528,9 @@ async fn start_cdp_quest(
                     cdp_port,
                     quest_id,
                     application_id,
+                    initial_progress,
                     times,
+                    client,
                     app_handle.clone(),
                     cancel_rx,
                 )

--- a/src/stores/quests.ts
+++ b/src/stores/quests.ts
@@ -571,21 +571,39 @@ export const useQuestsStore = defineStore('quests', () => {
 
       // Get checkpoint count from task config (default 3)
       const tasks = quest.config.task_config_v2?.tasks ?? quest.config.task_config?.tasks
-      const activityTask = tasks ? Object.values(tasks).find(t =>
-        t.type?.includes('ACTIVITY') || t.type?.includes('ACHIEVEMENT')
+      const activityTaskEntry = tasks ? Object.entries(tasks).find(([, task]) =>
+        task.type?.includes('ACTIVITY') || task.type?.includes('ACHIEVEMENT')
       ) : null
+      const activityTaskKey = activityTaskEntry?.[0]
+      const activityTask = activityTaskEntry?.[1] ?? null
       const checkpointCount = activityTask?.target || 3
+      const currentProgress = quest.user_status?.progress
+      const currentCheckpointValue = activityTaskKey && currentProgress?.[activityTaskKey]?.value != null
+        ? currentProgress[activityTaskKey].value ?? 0
+        : Object.values(currentProgress ?? {})[0]?.value ?? 0
+      const completedCheckpoints = Math.min(
+        checkpointCount,
+        Math.max(0, Math.floor(currentCheckpointValue))
+      )
+      const remainingCheckpointCount = Math.max(0, checkpointCount - completedCheckpoints)
+
+      if (remainingCheckpointCount === 0) {
+        throw new Error('Activity quest already has all checkpoints submitted. Refresh quests or claim the reward in Discord.')
+      }
 
       // Generate random checkpoint times within [min, max] range
       const min = activityCheckpointMin.value
       const max = activityCheckpointMax.value
-      const checkpointTimes: number[] = []
+      const allCheckpointTimes: number[] = []
       for (let i = 0; i < checkpointCount; i++) {
-        checkpointTimes.push(Math.floor(Math.random() * (max - min + 1)) + min)
+        allCheckpointTimes.push(Math.floor(Math.random() * (max - min + 1)) + min)
       }
-      const totalSeconds = checkpointTimes.reduce((sum, t) => sum + t, 0)
+      const checkpointTimes = allCheckpointTimes.slice(completedCheckpoints)
+      const totalSeconds = allCheckpointTimes.reduce((sum, t) => sum + t, 0)
+      const remainingSeconds = checkpointTimes.reduce((sum, t) => sum + t, 0)
+      const progressPct = checkpointCount > 0 ? (completedCheckpoints / checkpointCount) * 100 : 0
 
-      console.log(`Starting activity quest via CDP: ${checkpointCount} checkpoints, times=[${checkpointTimes.join(', ')}], total=${totalSeconds}s`)
+      console.log(`Starting activity quest via CDP: completed=${completedCheckpoints}/${checkpointCount}, remaining=${remainingCheckpointCount}, times=[${checkpointTimes.join(', ')}], remaining=${remainingSeconds}s, estimatedTotal=${totalSeconds}s`)
 
       const appId = quest.config.application?.id || ''
       const appName = quest.config.application?.name || quest.config.messages?.quest_name || 'Activity'
@@ -596,14 +614,14 @@ export const useQuestsStore = defineStore('quests', () => {
         appId,
         appName,
         totalSeconds,
-        0,
+        completedCheckpoints,
         cdpPort.value,
         checkpointTimes
       )
 
       activeQuestId.value = quest.id
       activeQuestType.value = 'activity'
-      activeQuestProgress.value = 0
+      activeQuestProgress.value = progressPct
       activeQuestTargetDuration.value = totalSeconds
 
       startProgressSimulation(1.0)


### PR DESCRIPTION
Add helpers to identify and describe activity iframe CDP targets and allow selecting a target by Discord application ID. Introduce find_activity_iframe_target_for_application while keeping the old wrapper. Rewrite the iframe JS (init and status) with timeouts, robust error serialization, SDK readiness checks, and richer return payloads (including startTimerIgnored). Update complete_activity_quest_via_cdp to accept application_id, produce sanitized hints, use the new finder, handle startTimer edge cases, track quest-completed dispatch success, and adjust progress/error emission accordingly. Pass application_id through lib initialization.

## Summary by Sourcery

Improve CDP-based activity quest completion by making iframe target selection application-aware and hardening the in-iframe Discord SDK interaction and verification flow.

New Features:
- Allow selecting the activity iframe CDP target by Discord application ID, with fallbacks and logging when no exact match is found.

Enhancements:
- Harden the activity iframe quest init and status JavaScript to handle SDK readiness, timeouts, richer error serialization, and multiple verification paths.
- Enrich quest completion tracking by recognizing when questStartTimer failures can be safely ignored and by treating successful quest-completed dispatch as sufficient when server verification lags.
- Sanitize quest and application identifiers in logs when running CDP activity quests.
- Route the application_id parameter through CDP quest startup so it is available to target selection.

Build:
- Bump frontend dependencies including Vue, Tauri CLI, PostCSS, TSX, Vite, and Vitest versions.