### PR TITLE
feat(cdp): align running-game spoof with live Discord scanner schema

### DIFF
--- a/src-tauri/src/cdp_game_spoof.rs
+++ b/src-tauri/src/cdp_game_spoof.rs
@@ -1,0 +1,561 @@
+//! CDP play-quest spoof fidelity helpers.
+//!
+//! Live Discord CDP on Windows :9223 (2026-08-13) confirmed the scanner object
+//! keys below, including four own-properties that were `undefined` on a Chrome
+//! non-game. Official PLAY_ON_DESKTOP heartbeats in
+//! `discord-heartbeat-game-quest.har` are exactly 60s apart. Path and
+//! executable selection are OS-specific:
+//!
+//! - Windows: `win32` + `C:\Program Files\...`
+//! - macOS: Unix-family — prefer `darwin`, emit `/Applications/*.app/Contents/MacOS/...`
+//! - Linux: Unix-family — prefer `linux`, emit `/opt/...`
+//!
+//! Simulation mode on macOS still uses win32 executable names; these helpers
+//! are for CDP store spoofing only.
+
+use once_cell::sync::Lazy;
+use rand::RngExt;
+use serde::Serialize;
+
+/// Discord detectable-game OS tags used by `/applications/public`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectableOs {
+    Win32,
+    Darwin,
+    Linux,
+}
+
+impl DetectableOs {
+    pub fn from_host() -> Self {
+        match std::env::consts::OS {
+            "macos" => Self::Darwin,
+            "linux" => Self::Linux,
+            _ => Self::Win32,
+        }
+    }
+
+    pub fn as_api_tag(self) -> &'static str {
+        match self {
+            Self::Win32 => "win32",
+            Self::Darwin => "darwin",
+            Self::Linux => "linux",
+        }
+    }
+
+    /// macOS and Linux share Unix process-name / path conventions for CDP spoof.
+    pub fn is_unix(self) -> bool {
+        matches!(self, Self::Darwin | Self::Linux)
+    }
+
+    /// Native tag first, then win32 so a Unix host still has a name to spoof.
+    /// Paths are always rendered for `self`, never as `C:\Program Files` on Unix.
+    pub fn cdp_executable_os_priority(self) -> &'static [&'static str] {
+        match self {
+            Self::Win32 => &["win32"],
+            Self::Darwin => &["darwin", "win32"],
+            Self::Linux => &["linux", "win32"],
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationExecutable {
+    pub os: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FakeGamePathTemplates {
+    pub cmd_line: &'static str,
+    pub exe_path: &'static str,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FakeGamePaths {
+    pub cmd_line: String,
+    pub exe_path: String,
+    pub exe_name: String,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunningGameIdentity<'a> {
+    pub id: &'a str,
+    pub pid: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SimulatedProcessHint {
+    pub pid: u32,
+    pub exe_name: String,
+    pub exe_path: String,
+    pub cmd_line: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CdpVideoTiming {
+    pub speed: u32,
+    pub interval: u32,
+    pub max_future: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CleanupVerify {
+    pub dqh_present: bool,
+    pub spoof_active: bool,
+    pub fake_game_present: bool,
+    pub has_dispatch_hook: bool,
+    pub broad_patch_count: u64,
+}
+
+/// Official Discord desktop game-quest heartbeat cadence, from
+/// `discord-heartbeat-game-quest.har` (60.000s ± 10ms between POSTs).
+pub const OFFICIAL_GAME_HEARTBEAT_SECS: u64 = 60;
+
+/// RunningGameStore object keys observed on a live Windows Discord client.
+/// Chrome non-game also owns `distributor`, `sku`, `gameMetadata`, and
+/// `executableFingerprint` as enumerable keys with `undefined` values.
+#[cfg(test)]
+pub const RUNNING_GAME_SCHEMA_KEYS: &[&str] = &[
+    "cmdLine",
+    "distributor",
+    "elevated",
+    "exeName",
+    "exePath",
+    "executableFingerprint",
+    "fullscreenType",
+    "gameMetadata",
+    "hidden",
+    "id",
+    "isLauncher",
+    "lastFocused",
+    "name",
+    "nativeProcessObserverId",
+    "origGameName",
+    "pid",
+    "pidPath",
+    "processName",
+    "sandboxed",
+    "sku",
+    "windowHandle",
+];
+
+pub fn cdp_bridge_name() -> &'static str {
+    static NAME: Lazy<String> = Lazy::new(|| {
+        let mut rng = rand::rng();
+        let suffix: String = (0..10)
+            .map(|_| format!("{:x}", rng.random::<u8>() % 16))
+            .collect();
+        format!("__n{suffix}")
+    });
+    NAME.as_str()
+}
+
+/// Rewrite the historical `__dqh_cdp` identifier to the process-scoped bridge.
+pub fn with_bridge(js: &str) -> String {
+    js.replace("__dqh_cdp", cdp_bridge_name())
+}
+
+pub fn path_templates(os: DetectableOs) -> FakeGamePathTemplates {
+    match os {
+        DetectableOs::Win32 => FakeGamePathTemplates {
+            cmd_line: r#""C:\Program Files\{app}\{exe}""#,
+            exe_path: r"c:/program files/{app_lower}/{exe}",
+        },
+        DetectableOs::Darwin => FakeGamePathTemplates {
+            cmd_line: "/Applications/{app}.app/Contents/MacOS/{exe}",
+            exe_path: "/Applications/{app}.app/Contents/MacOS/{exe}",
+        },
+        DetectableOs::Linux => FakeGamePathTemplates {
+            cmd_line: "/opt/{app_slug}/{exe}",
+            exe_path: "/opt/{app_slug}/{exe}",
+        },
+    }
+}
+
+#[cfg(test)]
+fn sanitize_app_name(app_name: &str) -> String {
+    app_name
+        .chars()
+        .map(|ch| match ch {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => ' ',
+            _ => ch,
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+fn normalize_exe_name(os: DetectableOs, raw: &str) -> String {
+    let trimmed = raw.trim().trim_start_matches('>');
+    let file = trimmed
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(trimmed)
+        .trim();
+    if os.is_unix() {
+        file.strip_suffix(".exe")
+            .or_else(|| file.strip_suffix(".EXE"))
+            .unwrap_or(file)
+            .to_string()
+    } else {
+        file.to_string()
+    }
+}
+
+#[cfg(test)]
+fn app_slug(app: &str) -> String {
+    app.to_lowercase().split_whitespace().collect::<Vec<_>>().join("-")
+}
+
+#[cfg(test)]
+fn render_template(template: &str, app: &str, exe: &str) -> String {
+    template
+        .replace("{app}", app)
+        .replace("{app_lower}", &app.to_lowercase())
+        .replace("{app_slug}", &app_slug(app))
+        .replace("{exe}", exe)
+}
+
+#[cfg(test)]
+fn build_fake_game_paths(os: DetectableOs, app_name: &str, exe_name: &str) -> FakeGamePaths {
+    let app = sanitize_app_name(app_name);
+    let exe = normalize_exe_name(os, exe_name);
+    let templates = path_templates(os);
+    FakeGamePaths {
+        cmd_line: render_template(templates.cmd_line, &app, &exe),
+        exe_path: render_template(templates.exe_path, &app, &exe),
+        exe_name: exe,
+    }
+}
+
+#[cfg(test)]
+fn select_executable<'a>(
+    executables: &'a [ApplicationExecutable],
+    priority: &[&str],
+) -> Option<&'a ApplicationExecutable> {
+    for os in priority {
+        if let Some(found) = executables.iter().find(|item| item.os == *os) {
+            return Some(found);
+        }
+    }
+    executables.first()
+}
+
+#[cfg(test)]
+fn merge_running_games<'a>(
+    real: &[RunningGameIdentity<'a>],
+    fake: RunningGameIdentity<'a>,
+) -> Vec<RunningGameIdentity<'a>> {
+    let mut merged: Vec<RunningGameIdentity<'a>> = real
+        .iter()
+        .copied()
+        .filter(|game| game.id != fake.id && game.pid != fake.pid)
+        .collect();
+    merged.push(fake);
+    merged
+}
+
+#[cfg(test)]
+fn match_process_hint<'a>(
+    hints: &'a [SimulatedProcessHint],
+    exe_name: &str,
+) -> Option<&'a SimulatedProcessHint> {
+    hints.iter().find(|hint| {
+        hint.exe_name.eq_ignore_ascii_case(exe_name)
+            || hint
+                .exe_path
+                .rsplit(['/', '\\'])
+                .next()
+                .is_some_and(|file| file.eq_ignore_ascii_case(exe_name))
+    })
+}
+
+pub fn cdp_video_timing() -> CdpVideoTiming {
+    CdpVideoTiming {
+        speed: 1,
+        interval: 1,
+        max_future: 10,
+    }
+}
+
+pub fn cdp_video_timeout_secs(seconds_needed: u32, initial_progress: f64) -> u64 {
+    let remaining = (seconds_needed as f64 - initial_progress).max(0.0);
+    let timing = cdp_video_timing();
+    let realtime = remaining / timing.speed.max(1) as f64;
+    (realtime * 2.0).ceil() as u64 + 300
+}
+
+pub fn align_play_activity_heartbeat_secs(requested: u64) -> u64 {
+    requested.max(OFFICIAL_GAME_HEARTBEAT_SECS)
+}
+
+pub fn cleanup_verify_is_clean(verify: &CleanupVerify) -> bool {
+    !verify.dqh_present
+        && !verify.spoof_active
+        && !verify.fake_game_present
+        && !verify.has_dispatch_hook
+        && verify.broad_patch_count == 0
+}
+
+pub fn cleanup_verify_from_json(parsed: &serde_json::Value) -> Option<CleanupVerify> {
+    if parsed.get("success") != Some(&serde_json::json!(true)) {
+        return None;
+    }
+    Some(CleanupVerify {
+        dqh_present: parsed
+            .get("dqhPresent")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        spoof_active: parsed
+            .get("spoofActive")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        fake_game_present: parsed
+            .get("fakeGamePresent")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        has_dispatch_hook: parsed
+            .get("hasDispatchHook")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        broad_patch_count: parsed
+            .get("broadPatchCount")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unix_hosts_prefer_native_executables_then_win32() {
+        assert_eq!(
+            DetectableOs::Linux.cdp_executable_os_priority(),
+            &["linux", "win32"]
+        );
+        assert_eq!(
+            DetectableOs::Darwin.cdp_executable_os_priority(),
+            &["darwin", "win32"]
+        );
+        assert_eq!(DetectableOs::Win32.cdp_executable_os_priority(), &["win32"]);
+        assert!(DetectableOs::Linux.is_unix());
+        assert!(DetectableOs::Darwin.is_unix());
+        assert!(!DetectableOs::Win32.is_unix());
+    }
+
+    #[test]
+    fn macos_and_linux_are_both_unix_family_for_cdp_spoof() {
+        for os in [DetectableOs::Darwin, DetectableOs::Linux] {
+            let paths = build_fake_game_paths(os, "Cool Game", ">Game.exe");
+            assert!(
+                !paths.cmd_line.contains("Program Files"),
+                "{os:?} must not emit Windows paths: {}",
+                paths.cmd_line
+            );
+            assert!(
+                !paths.exe_path.contains("program files"),
+                "{os:?} must not emit Windows paths: {}",
+                paths.exe_path
+            );
+            assert_eq!(paths.exe_name, "Game");
+        }
+    }
+
+    #[test]
+    fn macos_uses_application_bundle_paths() {
+        let paths = build_fake_game_paths(DetectableOs::Darwin, "Cool Game", "Cool Game");
+        assert_eq!(
+            paths.cmd_line,
+            "/Applications/Cool Game.app/Contents/MacOS/Cool Game"
+        );
+        assert_eq!(
+            paths.exe_path,
+            "/Applications/Cool Game.app/Contents/MacOS/Cool Game"
+        );
+    }
+
+    #[test]
+    fn linux_uses_opt_prefix_paths() {
+        let paths = build_fake_game_paths(DetectableOs::Linux, "Cool Game", "cool-game");
+        assert_eq!(paths.cmd_line, "/opt/cool-game/cool-game");
+        assert_eq!(paths.exe_path, "/opt/cool-game/cool-game");
+    }
+
+    #[test]
+    fn windows_keeps_program_files_shape() {
+        let paths = build_fake_game_paths(DetectableOs::Win32, "Cool Game", ">Game.exe");
+        assert_eq!(paths.cmd_line, r#""C:\Program Files\Cool Game\Game.exe""#);
+        assert_eq!(paths.exe_path, "c:/program files/cool game/Game.exe");
+        assert_eq!(paths.exe_name, "Game.exe");
+    }
+
+    #[test]
+    fn select_executable_prefers_first_matching_os() {
+        let executables = [
+            ApplicationExecutable {
+                os: "win32".into(),
+                name: "game.exe".into(),
+            },
+            ApplicationExecutable {
+                os: "darwin".into(),
+                name: "Game".into(),
+            },
+            ApplicationExecutable {
+                os: "linux".into(),
+                name: "game".into(),
+            },
+        ];
+        assert_eq!(
+            select_executable(&executables, &["darwin", "win32"])
+                .unwrap()
+                .name,
+            "Game"
+        );
+        assert_eq!(
+            select_executable(&executables, &["linux", "win32"])
+                .unwrap()
+                .name,
+            "game"
+        );
+        assert_eq!(
+            select_executable(&executables, &["win32"])
+                .unwrap()
+                .name,
+            "game.exe"
+        );
+    }
+
+    #[test]
+    fn unix_falls_back_to_win32_name_but_keeps_unix_paths() {
+        let executables = [ApplicationExecutable {
+            os: "win32".into(),
+            name: ">Title.exe".into(),
+        }];
+        let selected = select_executable(&executables, DetectableOs::Darwin.cdp_executable_os_priority())
+            .unwrap();
+        let paths = build_fake_game_paths(DetectableOs::Darwin, "Title", &selected.name);
+        assert_eq!(paths.exe_name, "Title");
+        assert!(paths.cmd_line.starts_with("/Applications/"));
+        assert!(!paths.cmd_line.contains(".exe"));
+    }
+
+    #[test]
+    fn merge_keeps_real_games_and_appends_fake() {
+        let real = [
+            RunningGameIdentity {
+                id: "other",
+                pid: 11,
+            },
+            RunningGameIdentity {
+                id: "stale",
+                pid: 22,
+            },
+        ];
+        let fake = RunningGameIdentity {
+            id: "stale",
+            pid: 99,
+        };
+        let merged = merge_running_games(&real, fake);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].id, "other");
+        assert_eq!(merged[1].id, "stale");
+        assert_eq!(merged[1].pid, 99);
+    }
+
+    #[test]
+    fn process_hint_matches_exe_name_or_path_basename() {
+        let hints = [SimulatedProcessHint {
+            pid: 4242,
+            exe_name: "Game".into(),
+            exe_path: "/Applications/Game.app/Contents/MacOS/Game".into(),
+            cmd_line: "/Applications/Game.app/Contents/MacOS/Game".into(),
+        }];
+        assert_eq!(match_process_hint(&hints, "Game").unwrap().pid, 4242);
+        assert_eq!(
+            match_process_hint(&hints, "game").unwrap().exe_path,
+            "/Applications/Game.app/Contents/MacOS/Game"
+        );
+        assert!(match_process_hint(&hints, "other").is_none());
+    }
+
+    #[test]
+    fn running_game_schema_lists_client_scanner_fields() {
+        for key in [
+            "exePath",
+            "cmdLine",
+            "pid",
+            "pidPath",
+            "exeName",
+            "nativeProcessObserverId",
+            "elevated",
+            "sandboxed",
+            "lastFocused",
+            "windowHandle",
+            "fullscreenType",
+            "origGameName",
+            "distributor",
+            "sku",
+            "gameMetadata",
+            "executableFingerprint",
+        ] {
+            assert!(RUNNING_GAME_SCHEMA_KEYS.contains(&key));
+        }
+    }
+
+    #[test]
+    fn official_heartbeat_is_sixty_seconds() {
+        assert_eq!(align_play_activity_heartbeat_secs(15), 60);
+        assert_eq!(align_play_activity_heartbeat_secs(60), 60);
+        assert_eq!(align_play_activity_heartbeat_secs(90), 90);
+    }
+
+    #[test]
+    fn video_timing_is_realtime_not_seven_x() {
+        let timing = cdp_video_timing();
+        assert_eq!(timing.speed, 1);
+        assert_eq!(timing.interval, 1);
+        assert_eq!(timing.max_future, 10);
+        assert_eq!(cdp_video_timeout_secs(700, 0.0), 1700);
+    }
+
+    #[test]
+    fn cleanup_verify_requires_every_hook_gone() {
+        let clean = CleanupVerify {
+            dqh_present: false,
+            spoof_active: false,
+            fake_game_present: false,
+            has_dispatch_hook: false,
+            broad_patch_count: 0,
+        };
+        assert!(cleanup_verify_is_clean(&clean));
+        assert!(!cleanup_verify_is_clean(&CleanupVerify {
+            has_dispatch_hook: true,
+            ..clean.clone()
+        }));
+        assert!(cleanup_verify_from_json(&serde_json::json!({
+            "success": true,
+            "dqhPresent": false,
+            "spoofActive": false,
+            "fakeGamePresent": false,
+            "hasDispatchHook": false,
+            "broadPatchCount": 0
+        }))
+        .is_some_and(|verify| cleanup_verify_is_clean(&verify)));
+    }
+
+    #[test]
+    fn with_bridge_strips_stable_dqh_identifier() {
+        let rewritten = with_bridge("window.__dqh_cdp = 1; delete window.__dqh_cdp;");
+        assert!(!rewritten.contains("__dqh_cdp"));
+        assert!(rewritten.contains(cdp_bridge_name()));
+        assert!(cdp_bridge_name().starts_with("__n"));
+    }
+}

--- a/src-tauri/src/cdp_game_spoof.rs
+++ b/src-tauri/src/cdp_game_spoof.rs
@@ -176,6 +176,9 @@ pub fn path_templates(os: DetectableOs) -> FakeGamePathTemplates {
     }
 }
 
+/// Test-only mirrors of the injected JavaScript helpers `sanitizeApp`,
+/// `normalizeExe`, `appSlug`, and `render` in `cdp_quest.rs`. Keep both
+/// implementations in lockstep.
 #[cfg(test)]
 fn sanitize_app_name(app_name: &str) -> String {
     app_name
@@ -193,16 +196,17 @@ fn sanitize_app_name(app_name: &str) -> String {
 #[cfg(test)]
 fn normalize_exe_name(os: DetectableOs, raw: &str) -> String {
     let trimmed = raw.trim().trim_start_matches('>');
-    let file = trimmed
-        .rsplit(['/', '\\'])
-        .next()
-        .unwrap_or(trimmed)
-        .trim();
+    let file = trimmed.rsplit(['/', '\\']).next().unwrap_or(trimmed).trim();
     if os.is_unix() {
-        file.strip_suffix(".exe")
-            .or_else(|| file.strip_suffix(".EXE"))
-            .unwrap_or(file)
-            .to_string()
+        let cut = file.len().saturating_sub(4);
+        if file
+            .get(cut..)
+            .is_some_and(|suffix| suffix.eq_ignore_ascii_case(".exe"))
+        {
+            file[..cut].to_string()
+        } else {
+            file.to_string()
+        }
     } else {
         file.to_string()
     }
@@ -210,7 +214,10 @@ fn normalize_exe_name(os: DetectableOs, raw: &str) -> String {
 
 #[cfg(test)]
 fn app_slug(app: &str) -> String {
-    app.to_lowercase().split_whitespace().collect::<Vec<_>>().join("-")
+    app.to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 #[cfg(test)]
@@ -278,8 +285,8 @@ fn match_process_hint<'a>(
 
 pub fn cdp_video_timing() -> CdpVideoTiming {
     CdpVideoTiming {
-        speed: 1,
-        interval: 1,
+        speed: 10,
+        interval: 10,
         max_future: 10,
     }
 }
@@ -287,8 +294,8 @@ pub fn cdp_video_timing() -> CdpVideoTiming {
 pub fn cdp_video_timeout_secs(seconds_needed: u32, initial_progress: f64) -> u64 {
     let remaining = (seconds_needed as f64 - initial_progress).max(0.0);
     let timing = cdp_video_timing();
-    let realtime = remaining / timing.speed.max(1) as f64;
-    (realtime * 2.0).ceil() as u64 + 300
+    let wall = remaining * timing.interval.max(1) as f64 / timing.speed.max(1) as f64;
+    (wall * 2.0).ceil() as u64 + 300
 }
 
 pub fn align_play_activity_heartbeat_secs(requested: u64) -> u64 {
@@ -366,6 +373,10 @@ mod tests {
                 paths.exe_path
             );
             assert_eq!(paths.exe_name, "Game");
+            assert_eq!(
+                build_fake_game_paths(os, "Cool Game", "Game.Exe").exe_name,
+                "Game"
+            );
         }
     }
 
@@ -426,9 +437,7 @@ mod tests {
             "game"
         );
         assert_eq!(
-            select_executable(&executables, &["win32"])
-                .unwrap()
-                .name,
+            select_executable(&executables, &["win32"]).unwrap().name,
             "game.exe"
         );
     }
@@ -439,8 +448,11 @@ mod tests {
             os: "win32".into(),
             name: ">Title.exe".into(),
         }];
-        let selected = select_executable(&executables, DetectableOs::Darwin.cdp_executable_os_priority())
-            .unwrap();
+        let selected = select_executable(
+            &executables,
+            DetectableOs::Darwin.cdp_executable_os_priority(),
+        )
+        .unwrap();
         let paths = build_fake_game_paths(DetectableOs::Darwin, "Title", &selected.name);
         assert_eq!(paths.exe_name, "Title");
         assert!(paths.cmd_line.starts_with("/Applications/"));
@@ -520,9 +532,9 @@ mod tests {
     #[test]
     fn video_timing_is_realtime_not_seven_x() {
         let timing = cdp_video_timing();
-        assert_eq!(timing.speed, 1);
-        assert_eq!(timing.interval, 1);
+        assert_eq!(timing.speed, timing.interval);
         assert_eq!(timing.max_future, 10);
+        assert_ne!(timing.speed, 7);
         assert_eq!(cdp_video_timeout_secs(700, 0.0), 1700);
     }
 

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -26,6 +26,8 @@ const QUEST_HOME_DETOUR_URL: &str = "https://discord.com/store";
 const QUEST_WARMUP_NAV_TIMEOUT_SECS: u64 = 20;
 const QUEST_WARMUP_DWELL_MS: u64 = 1500;
 const QUEST_WARMUP_RESTORE_SETTLE_MS: u64 = 800;
+const CDP_CLEANUP_ATTEMPTS: u32 = 5;
+const CDP_CLEANUP_CANCEL_ATTEMPTS: u32 = 1;
 
 /// JavaScript: Initialize quest-related Discord webpack modules and store them in window.__dqh_cdp.
 ///
@@ -301,7 +303,8 @@ fn js_spoof_play_game_for(
 ) -> String {
     let safe_app_id = serde_json::to_string(app_id).unwrap_or_else(|_| "\"\"".to_string());
     let safe_app_name = serde_json::to_string(app_name).unwrap_or_else(|_| "\"\"".to_string());
-    let host_os_json = serde_json::to_string(host_os.as_api_tag()).unwrap_or_else(|_| "\"win32\"".to_string());
+    let host_os_json =
+        serde_json::to_string(host_os.as_api_tag()).unwrap_or_else(|_| "\"win32\"".to_string());
     let os_priority_json = serde_json::to_string(host_os.cdp_executable_os_priority())
         .unwrap_or_else(|_| "[\"win32\"]".to_string());
     let templates = path_templates(host_os);
@@ -431,11 +434,19 @@ fn js_spoof_play_game_for(
         function patchedGetGameForPID(p) {{
             return patchedGetRunningGames().find(x => x.pid === p);
         }}
+        function patchVisibleAccessor(store, origVisible) {{
+            if (typeof origVisible !== "function") return;
+            store.getVisibleRunningGames = function () {{
+                let games = [];
+                try {{ games = origVisible.call(store); }} catch(e) {{
+                    try {{ games = origVisible(); }} catch(e2) {{ games = []; }}
+                }}
+                return mergeFake(games, dqh._fakeGame);
+            }};
+        }}
         dqh.RunningGameStore.getRunningGames = patchedGetRunningGames;
         dqh.RunningGameStore.getGameForPID = patchedGetGameForPID;
-        if (typeof dqh.RunningGameStore.getVisibleRunningGames === "function") {{
-            dqh.RunningGameStore.getVisibleRunningGames = patchedGetRunningGames;
-        }}
+        patchVisibleAccessor(dqh.RunningGameStore, dqh._origGetVisibleRunningGames);
 
         let patchCount = 1;
         const broadPatched = [];
@@ -458,7 +469,7 @@ fn js_spoof_play_game_for(
                                 const origVisibleFn = typeof val.getVisibleRunningGames === 'function' ? val.getVisibleRunningGames : null;
                                 val.getRunningGames = patchedGetRunningGames;
                                 if (origPidFn) val.getGameForPID = patchedGetGameForPID;
-                                if (origVisibleFn) val.getVisibleRunningGames = patchedGetRunningGames;
+                                patchVisibleAccessor(val, origVisibleFn);
                                 broadPatched.push({{ val, origFn, origPidFn, origVisibleFn }});
                                 patchCount++;
                             }}
@@ -635,9 +646,9 @@ fn js_start_video_quest(quest_id: &str, seconds_needed: u32, initial_seconds: f6
             try {{
                 let secondsDone = {initial_seconds};
                 const enrolledAt = new Date(quest.userStatus.enrolledAt).getTime();
-        const speed = {video_speed};
-        const interval = {video_interval};
-        const maxFuture = {video_max_future};
+                const speed = {video_speed};
+                const interval = {video_interval};
+                const maxFuture = {video_max_future};
                 let completed = false;
                 let consecutiveErrors = 0;
                 const maxErrors = 10;
@@ -861,83 +872,103 @@ fn js_query_progress(quest_id: &str) -> String {
 }
 
 /// JavaScript: Cleanup spoofed store functions, restoring originals.
+///
+/// Discovers leftover bridges from earlier app processes (`__n` + 10 hex) and
+/// the historical `__dqh_cdp` name. The historical name is split so
+/// `with_bridge` cannot rewrite the lookup.
 const JS_CLEANUP_SPOOF: &str = r#"
 (() => {
     try {
-        const dqh = window.__dqh_cdp;
-        if (!dqh) return JSON.stringify({ success: true, message: "Nothing to clean up" });
-
-        // Deactivate spoof FIRST so the dispatch interceptor stops re-injecting
-        dqh._spoofActive = false;
-
-        // Restore FluxDispatcher.dispatch (remove our interceptor)
-        if (dqh._origDispatch) {
-            dqh.FluxDispatcher.dispatch = dqh._origDispatch;
-            delete dqh._origDispatch;
+        const historical = "__" + "dqh_cdp";
+        const names = Object.getOwnPropertyNames(window).filter(k =>
+            k === historical || /^__n[0-9a-f]{10}$/.test(k)
+        );
+        function isDqhBridge(obj) {
+            return !!(obj && typeof obj === "object" && (
+                typeof obj._origGetRunningGames === "function"
+                || obj._spoofActive === true
+                || obj._fakeGame
+                || obj._origDispatch
+                || (obj.initialized === true && obj.RunningGameStore)
+            ));
         }
+        function cleanupOne(dqh, name) {
+            dqh._spoofActive = false;
 
-        // Restore original functions (same pattern as gist)
-        if (dqh._origGetRunningGames) {
-            dqh.RunningGameStore.getRunningGames = dqh._origGetRunningGames;
-        }
-        if (typeof dqh._origGetGameForPID === "function") {
-            dqh.RunningGameStore.getGameForPID = dqh._origGetGameForPID;
-        } else {
-            // If the original store had no getGameForPID, remove the spoofed method.
+            if (dqh._origDispatch && dqh.FluxDispatcher) {
+                dqh.FluxDispatcher.dispatch = dqh._origDispatch;
+                delete dqh._origDispatch;
+            }
+
+            if (dqh.RunningGameStore) {
+                if (dqh._origGetRunningGames) {
+                    dqh.RunningGameStore.getRunningGames = dqh._origGetRunningGames;
+                }
+                if (typeof dqh._origGetGameForPID === "function") {
+                    dqh.RunningGameStore.getGameForPID = dqh._origGetGameForPID;
+                } else {
+                    try {
+                        delete dqh.RunningGameStore.getGameForPID;
+                    } catch(e) {
+                        dqh.RunningGameStore.getGameForPID = undefined;
+                    }
+                }
+                if (typeof dqh._origGetVisibleRunningGames === "function") {
+                    dqh.RunningGameStore.getVisibleRunningGames = dqh._origGetVisibleRunningGames;
+                }
+            }
+            if (dqh._origGetStreamerActiveStreamMetadata && dqh.ApplicationStreamingStore) {
+                dqh.ApplicationStreamingStore.getStreamerActiveStreamMetadata = dqh._origGetStreamerActiveStreamMetadata;
+            }
+
+            if (Array.isArray(dqh._broadPatched)) {
+                for (const patch of dqh._broadPatched) {
+                    try {
+                        patch.val.getRunningGames = patch.origFn;
+                        if (patch.origPidFn) patch.val.getGameForPID = patch.origPidFn;
+                        if (patch.origVisibleFn) patch.val.getVisibleRunningGames = patch.origVisibleFn;
+                    } catch(e) {}
+                }
+            }
+
+            if (dqh.FluxDispatcher && dqh._heartbeatFn) {
+                dqh.FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", dqh._heartbeatFn);
+            }
+            if (dqh.FluxDispatcher && dqh._heartbeatFailFn) {
+                dqh.FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_FAILURE", dqh._heartbeatFailFn);
+            }
+
+            let remaining = [];
             try {
-                delete dqh.RunningGameStore.getGameForPID;
-            } catch(e) {
-                dqh.RunningGameStore.getGameForPID = undefined;
+                remaining = dqh._origGetRunningGames && dqh.RunningGameStore
+                    ? dqh._origGetRunningGames.call(dqh.RunningGameStore)
+                    : [];
+            } catch (e) {
+                remaining = [];
             }
-        }
-        if (typeof dqh._origGetVisibleRunningGames === "function") {
-            dqh.RunningGameStore.getVisibleRunningGames = dqh._origGetVisibleRunningGames;
-        }
-        if (dqh._origGetStreamerActiveStreamMetadata) {
-            dqh.ApplicationStreamingStore.getStreamerActiveStreamMetadata = dqh._origGetStreamerActiveStreamMetadata;
-        }
+            if (!Array.isArray(remaining)) remaining = [];
+            if (dqh._fakeGame) {
+                remaining = remaining.filter(g => g && g.id !== dqh._fakeGame.id && g.pid !== dqh._fakeGame.pid);
+            }
+            if (dqh.FluxDispatcher && dqh._fakeGame) {
+                dqh.FluxDispatcher.dispatch({ type: "RUNNING_GAMES_CHANGE", removed: [dqh._fakeGame], added: [], games: remaining });
+            }
 
-        // Restore broadly patched modules BEFORE dispatching removal event
-        // Otherwise heartbeat manager may re-query getRunningGames() from a still-patched
-        // module and re-detect the fake game immediately after removal
-        if (Array.isArray(dqh._broadPatched)) {
-            for (const patch of dqh._broadPatched) {
-                try {
-                    patch.val.getRunningGames = patch.origFn;
-                    if (patch.origPidFn) patch.val.getGameForPID = patch.origPidFn;
-                    if (patch.origVisibleFn) patch.val.getVisibleRunningGames = patch.origVisibleFn;
-                } catch(e) {}
+            try {
+                delete window[name];
+            } catch (e) {
+                try { window[name] = undefined; } catch (e2) {}
             }
         }
 
-        // Unsubscribe heartbeat listeners BEFORE dispatching removal
-        if (dqh.FluxDispatcher && dqh._heartbeatFn) {
-            dqh.FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", dqh._heartbeatFn);
+        let cleaned = 0;
+        for (const name of names) {
+            const dqh = window[name];
+            if (!isDqhBridge(dqh)) continue;
+            cleanupOne(dqh, name);
+            cleaned++;
         }
-        if (dqh.FluxDispatcher && dqh._heartbeatFailFn) {
-            dqh.FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_FAILURE", dqh._heartbeatFailFn);
-        }
-
-        // Restore originals first, then tell Discord the fake game left while
-        // keeping any real games the native scanner still sees.
-        let remaining = [];
-        try {
-            remaining = dqh._origGetRunningGames
-                ? dqh._origGetRunningGames.call(dqh.RunningGameStore)
-                : [];
-        } catch (e) {
-            remaining = [];
-        }
-        if (!Array.isArray(remaining)) remaining = [];
-        if (dqh._fakeGame) {
-            remaining = remaining.filter(g => g && g.id !== dqh._fakeGame.id && g.pid !== dqh._fakeGame.pid);
-        }
-        if (dqh.FluxDispatcher && dqh._fakeGame) {
-            dqh.FluxDispatcher.dispatch({ type: "RUNNING_GAMES_CHANGE", removed: [dqh._fakeGame], added: [], games: remaining });
-        }
-
-        delete window.__dqh_cdp;
-        return JSON.stringify({ success: true });
+        return JSON.stringify({ success: true, cleaned });
     } catch (e) {
         return JSON.stringify({ success: false, error: String(e) });
     }
@@ -948,14 +979,40 @@ const JS_CLEANUP_SPOOF: &str = r#"
 const JS_VERIFY_CLEANUP_STATE: &str = r#"
 (() => {
     try {
-        const dqh = window.__dqh_cdp;
+        const historical = "__" + "dqh_cdp";
+        const names = Object.getOwnPropertyNames(window).filter(k =>
+            k === historical || /^__n[0-9a-f]{10}$/.test(k)
+        );
+        function isDqhBridge(obj) {
+            return !!(obj && typeof obj === "object" && (
+                typeof obj._origGetRunningGames === "function"
+                || obj._spoofActive === true
+                || obj._fakeGame
+                || obj._origDispatch
+                || (obj.initialized === true && obj.RunningGameStore)
+            ));
+        }
+        let dqhPresent = false;
+        let spoofActive = false;
+        let fakeGamePresent = false;
+        let hasDispatchHook = false;
+        let broadPatchCount = 0;
+        for (const name of names) {
+            const dqh = window[name];
+            if (!isDqhBridge(dqh)) continue;
+            dqhPresent = true;
+            spoofActive = spoofActive || !!dqh._spoofActive;
+            fakeGamePresent = fakeGamePresent || !!dqh._fakeGame;
+            hasDispatchHook = hasDispatchHook || !!dqh._origDispatch;
+            broadPatchCount += Array.isArray(dqh._broadPatched) ? dqh._broadPatched.length : 0;
+        }
         return JSON.stringify({
             success: true,
-            dqhPresent: !!dqh,
-            spoofActive: !!dqh?._spoofActive,
-            fakeGamePresent: !!dqh?._fakeGame,
-            hasDispatchHook: !!dqh?._origDispatch,
-            broadPatchCount: Array.isArray(dqh?._broadPatched) ? dqh._broadPatched.length : 0
+            dqhPresent,
+            spoofActive,
+            fakeGamePresent,
+            hasDispatchHook,
+            broadPatchCount
         });
     } catch (e) {
         return JSON.stringify({ success: false, error: String(e) });
@@ -1234,12 +1291,14 @@ async fn cdp_execute_json_on_all_targets(
     operation: &str,
 ) -> Result<CdpJsonExecutionSummary> {
     let rewritten = with_bridge(js_code);
-    let results =
-        cdp_client::execute_js_via_all_discord_targets(port, &rewritten, await_promise, timeout_secs)
-            .await
-            .with_context(|| {
-                format!("Failed to execute CDP {} across Discord targets", operation)
-            })?;
+    let results = cdp_client::execute_js_via_all_discord_targets(
+        port,
+        &rewritten,
+        await_promise,
+        timeout_secs,
+    )
+    .await
+    .with_context(|| format!("Failed to execute CDP {} across Discord targets", operation))?;
 
     let total_targets = results.len();
     let mut successful_results = Vec::new();
@@ -1529,10 +1588,14 @@ fn parse_play_activity_cdp_status(raw: &str) -> Result<PlayActivityHeartbeatStat
 }
 
 async fn cdp_init_modules_on_primary(port: u16) -> Result<()> {
-    let raw =
-        cdp_client::execute_js_via_primary_discord_target(port, &with_bridge(JS_INIT_QUEST_MODULES), true, 60)
-            .await
-            .context("Failed to initialize Discord modules on the primary CDP target")?;
+    let raw = cdp_client::execute_js_via_primary_discord_target(
+        port,
+        &with_bridge(JS_INIT_QUEST_MODULES),
+        true,
+        60,
+    )
+    .await
+    .context("Failed to initialize Discord modules on the primary CDP target")?;
     let parsed: serde_json::Value =
         serde_json::from_str(&raw).context("CDP module initialization returned invalid JSON")?;
     if parsed.get("success").and_then(|value| value.as_bool()) == Some(true) {
@@ -1572,15 +1635,42 @@ async fn cdp_get_play_activity_status(
     parse_play_activity_cdp_status(&raw)
 }
 
+fn log_cdp_cleanup_failure(context: &str, err: &anyhow::Error) {
+    use crate::logger::{log, LogCategory, LogLevel};
+    log(
+        LogLevel::Error,
+        LogCategory::TokenExtraction,
+        &format!(
+            "CDP cleanup failed ({context}): {err}. Restart Discord if a spoofed game remains visible."
+        ),
+        None,
+    );
+}
+
+async fn cdp_cleanup_best_effort(port: u16) {
+    let _ = cdp_cleanup_with_attempts(port, CDP_CLEANUP_ATTEMPTS).await;
+}
+
+async fn cdp_cleanup_after_stop(port: u16, context: &str, cancelled: bool) {
+    let attempts = if cancelled {
+        CDP_CLEANUP_CANCEL_ATTEMPTS
+    } else {
+        CDP_CLEANUP_ATTEMPTS
+    };
+    if let Err(err) = cdp_cleanup_with_attempts(port, attempts).await {
+        log_cdp_cleanup_failure(context, &err);
+    }
+}
+
 /// Cleanup spoofed stores via CDP and verify every Discord page target is clean.
-async fn cdp_cleanup(port: u16) -> Result<()> {
+async fn cdp_cleanup_with_attempts(port: u16, max_attempts: u32) -> Result<()> {
     use crate::logger::{log, LogCategory, LogLevel};
 
-    const MAX_ATTEMPTS: u32 = 5;
+    let max_attempts = max_attempts.max(1);
     let cleanup_js = with_bridge(JS_CLEANUP_SPOOF);
     let verify_js = with_bridge(JS_VERIFY_CLEANUP_STATE);
 
-    for attempt in 1..=MAX_ATTEMPTS {
+    for attempt in 1..=max_attempts {
         let mut cleanup_success_count = 0usize;
 
         match cdp_client::execute_js_via_all_discord_targets(port, &cleanup_js, false, 5).await {
@@ -1732,7 +1822,7 @@ async fn cdp_cleanup(port: u16) -> Result<()> {
             }
         }
 
-        if attempt < MAX_ATTEMPTS {
+        if attempt < max_attempts {
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
     }
@@ -1901,7 +1991,7 @@ pub async fn complete_play_quest_via_cdp(
 
     // Defensive pre-cleanup: prevent stale spoof state from a previous run from leaking
     // into the new quest session.
-    let _ = cdp_cleanup(port).await;
+    cdp_cleanup_best_effort(port).await;
     cdp_warmup_quest_route(port).await;
 
     // 1. Init modules
@@ -1915,7 +2005,7 @@ pub async fn complete_play_quest_via_cdp(
         match cdp_execute_json_on_all_targets(port, &js, true, 15, "play quest spoof").await {
             Ok(summary) => summary,
             Err(err) => {
-                let _ = cdp_cleanup(port).await;
+                cdp_cleanup_after_stop(port, "play quest spoof failed", false).await;
                 return Err(err);
             }
         };
@@ -1977,7 +2067,7 @@ pub async fn complete_play_quest_via_cdp(
             _ = sleep(poll_interval) => {},
             _ = cancel_rx.recv() => {
                 log(LogLevel::Info, LogCategory::TokenExtraction, "CDP play quest cancelled", None);
-                let _ = cdp_cleanup(port).await;
+                cdp_cleanup_after_stop(port, "play quest cancelled", true).await;
                 let _ = app_handle.emit("quest-stopped", ());
                 return Ok(());
             }
@@ -2053,7 +2143,7 @@ pub async fn complete_play_quest_via_cdp(
                 "CDP play quest completed!",
                 None,
             );
-            let _ = cdp_cleanup(port).await;
+            cdp_cleanup_after_stop(port, "play quest completed", false).await;
             let _ = app_handle.emit("quest-complete", ());
             return Ok(());
         }
@@ -2084,7 +2174,7 @@ pub async fn complete_stream_quest_via_cdp(
     );
 
     // Defensive pre-cleanup: ensure previous spoof state is removed before applying new patches.
-    let _ = cdp_cleanup(port).await;
+    cdp_cleanup_best_effort(port).await;
     cdp_warmup_quest_route(port).await;
 
     // 1. Init modules
@@ -2098,7 +2188,7 @@ pub async fn complete_stream_quest_via_cdp(
         match cdp_execute_json_on_all_targets(port, &js, false, 10, "stream quest spoof").await {
             Ok(summary) => summary,
             Err(err) => {
-                let _ = cdp_cleanup(port).await;
+                cdp_cleanup_after_stop(port, "stream quest spoof failed", false).await;
                 return Err(err);
             }
         };
@@ -2139,7 +2229,7 @@ pub async fn complete_stream_quest_via_cdp(
             _ = sleep(poll_interval) => {},
             _ = cancel_rx.recv() => {
                 log(LogLevel::Info, LogCategory::TokenExtraction, "CDP stream quest cancelled", None);
-                let _ = cdp_cleanup(port).await;
+                cdp_cleanup_after_stop(port, "stream quest cancelled", true).await;
                 let _ = app_handle.emit("quest-stopped", ());
                 return Ok(());
             }
@@ -2215,7 +2305,7 @@ pub async fn complete_stream_quest_via_cdp(
                 "CDP stream quest completed!",
                 None,
             );
-            let _ = cdp_cleanup(port).await;
+            cdp_cleanup_after_stop(port, "stream quest completed", false).await;
             let _ = app_handle.emit("quest-complete", ());
             return Ok(());
         }
@@ -2248,7 +2338,7 @@ pub async fn complete_video_quest_via_cdp(
     );
 
     // Defensive pre-cleanup for cross-quest consistency.
-    let _ = cdp_cleanup(port).await;
+    cdp_cleanup_best_effort(port).await;
     cdp_warmup_quest_route(port).await;
 
     // 1. Init modules
@@ -2288,9 +2378,8 @@ pub async fn complete_video_quest_via_cdp(
 
     // 3. Poll progress until the JS loop finishes (videoRunning=false) or quest completes
     let poll_interval = Duration::from_secs(5);
-    let max_duration = Duration::from_secs(
-        cdp_video_timeout_secs(seconds_needed, initial_progress),
-    );
+    let max_duration =
+        Duration::from_secs(cdp_video_timeout_secs(seconds_needed, initial_progress));
     let start_time = std::time::Instant::now();
 
     loop {
@@ -2306,6 +2395,7 @@ pub async fn complete_video_quest_via_cdp(
                     5,
                     "video quest stop signal"
                 ).await;
+                cdp_cleanup_after_stop(port, "video quest cancelled", true).await;
                 let _ = app_handle.emit("quest-stopped", ());
                 return Ok(());
             }
@@ -2352,7 +2442,7 @@ pub async fn complete_video_quest_via_cdp(
                     );
                     let _ = app_handle.emit("quest-progress", 100.0f64);
                     let _ = app_handle.emit("quest-complete", ());
-                    let _ = cdp_cleanup(port).await;
+                    cdp_cleanup_after_stop(port, "video quest completed", false).await;
                     return Ok(());
                 }
             }
@@ -2417,7 +2507,7 @@ pub async fn complete_video_quest_via_cdp(
                                     let _ = app_handle.emit("quest-progress", progress_pct);
                                     let _ = app_handle.emit("quest-error", "Video quest finished but server has not confirmed completion. Please check quest status in Discord.".to_string());
                                 }
-                                let _ = cdp_cleanup(port).await;
+                                cdp_cleanup_after_stop(port, "video quest finished", false).await;
                                 return Ok(());
                             } else {
                                 let error = parsed.get("error")
@@ -3036,7 +3126,7 @@ async fn confirm_play_activity_via_cdp(
             tokio::select! {
                 _ = sleep(Duration::from_secs(2)) => {},
                 _ = cancel_rx.recv() => {
-                    let _ = cdp_cleanup(port).await;
+                    cdp_cleanup_after_stop(port, "PLAY_ACTIVITY confirm cancelled", true).await;
                     let _ = app_handle.emit("quest-stopped", ());
                     return Ok(());
                 }
@@ -3044,7 +3134,7 @@ async fn confirm_play_activity_via_cdp(
         }
     }
 
-    let _ = cdp_cleanup(port).await;
+    cdp_cleanup_after_stop(port, "PLAY_ACTIVITY confirm finished", false).await;
     if confirmed {
         let _ = app_handle.emit("quest-progress", 100.0f64);
         let _ = app_handle.emit("quest-complete", ());
@@ -3081,10 +3171,10 @@ pub async fn complete_play_activity_via_cdp(
         anyhow::bail!("PLAY_ACTIVITY intervals must be greater than zero");
     }
 
-    let _ = cdp_cleanup(port).await;
+    cdp_cleanup_best_effort(port).await;
     cdp_warmup_quest_route(port).await;
     if let Err(error) = cdp_init_modules_on_primary(port).await {
-        let _ = cdp_cleanup(port).await;
+        cdp_cleanup_after_stop(port, "PLAY_ACTIVITY init failed", false).await;
         return Err(error.context("Failed to initialize CDP modules for PLAY_ACTIVITY"));
     }
 
@@ -3114,7 +3204,7 @@ pub async fn complete_play_activity_via_cdp(
             if session_started {
                 let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
             }
-            let _ = cdp_cleanup(port).await;
+            cdp_cleanup_after_stop(port, "PLAY_ACTIVITY cancelled", true).await;
             let _ = app_handle.emit("quest-stopped", ());
             return Ok(());
         }
@@ -3123,7 +3213,7 @@ pub async fn complete_play_activity_via_cdp(
             if session_started {
                 let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
             }
-            let _ = cdp_cleanup(port).await;
+            cdp_cleanup_after_stop(port, "PLAY_ACTIVITY timed out", false).await;
             anyhow::bail!("PLAY_ACTIVITY timed out before Discord confirmed completion");
         }
 
@@ -3156,7 +3246,7 @@ pub async fn complete_play_activity_via_cdp(
                     if session_started {
                         let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
                     }
-                    let _ = cdp_cleanup(port).await;
+                    cdp_cleanup_after_stop(port, "PLAY_ACTIVITY heartbeat failed", false).await;
                     return Err(error.context("CDP PLAY_ACTIVITY heartbeat failed three times"));
                 }
 
@@ -3167,7 +3257,7 @@ pub async fn complete_play_activity_via_cdp(
                         if session_started {
                             let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
                         }
-                        let _ = cdp_cleanup(port).await;
+                        cdp_cleanup_after_stop(port, "PLAY_ACTIVITY cancelled during retry", true).await;
                         let _ = app_handle.emit("quest-stopped", ());
                         return Ok(());
                     }
@@ -3195,7 +3285,7 @@ pub async fn complete_play_activity_via_cdp(
                 _ = sleep_until(wake_at) => {},
                 _ = cancel_rx.recv() => {
                     let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
-                    let _ = cdp_cleanup(port).await;
+                    cdp_cleanup_after_stop(port, "PLAY_ACTIVITY cancelled while waiting", true).await;
                     let _ = app_handle.emit("quest-stopped", ());
                     return Ok(());
                 }
@@ -3204,7 +3294,7 @@ pub async fn complete_play_activity_via_cdp(
             let now = Instant::now();
             if now >= timeout_at {
                 let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
-                let _ = cdp_cleanup(port).await;
+                cdp_cleanup_after_stop(port, "PLAY_ACTIVITY timed out while waiting", false).await;
                 anyhow::bail!("PLAY_ACTIVITY timed out before Discord confirmed completion");
             }
 
@@ -3659,9 +3749,8 @@ mod tests {
     fn init_js_requires_getrunninggames_to_return_array() {
         assert!(JS_INIT_QUEST_MODULES.contains("Array.isArray(games)"));
         assert!(JS_INIT_QUEST_MODULES.contains("const games = val.getRunningGames();"));
-        assert!(!JS_INIT_QUEST_MODULES.contains(
-            "if (!modules.RunningGameStore && val?.getRunningGames)"
-        ));
+        assert!(!JS_INIT_QUEST_MODULES
+            .contains("if (!modules.RunningGameStore && val?.getRunningGames)"));
     }
 
     #[test]
@@ -3684,6 +3773,9 @@ mod tests {
             assert!(js.contains(field), "missing live scanner field {field}");
         }
         assert!(js.contains("if (!Array.isArray(sample)) continue"));
+        assert!(js.contains("patchVisibleAccessor"));
+        assert!(js.contains(r#"split("{app}")"#));
+        assert!(!js.contains(r#"split("{{app}}")"#));
     }
 
     #[test]
@@ -3715,13 +3807,19 @@ mod tests {
         for os in [DetectableOs::Linux, DetectableOs::Darwin] {
             let js = js_spoof_play_game_for("123", "Cool Game", os, Vec::new());
             assert!(!js.contains("Program Files"), "{os:?} leaked Windows paths");
-            assert!(js.contains("mergeFake"), "{os:?} must merge real running games");
-            assert!(js.contains("removed: []"), "{os:?} must not drop real games");
+            assert!(
+                js.contains("mergeFake"),
+                "{os:?} must merge real running games"
+            );
+            assert!(
+                js.contains("removed: []"),
+                "{os:?} must not drop real games"
+            );
             assert!(!js.contains("const fakeGames = [fakeGame]"));
         }
 
         let linux = js_spoof_play_game_for("123", "Cool Game", DetectableOs::Linux, Vec::new());
-        assert!(linux.contains("/opt/{app_slug}/{exe}") || linux.contains("/opt/"));
+        assert!(linux.contains(path_templates(DetectableOs::Linux).exe_path));
         assert!(linux.contains("\"linux\""));
 
         let darwin = js_spoof_play_game_for("123", "Cool Game", DetectableOs::Darwin, Vec::new());
@@ -3740,8 +3838,10 @@ mod tests {
     #[test]
     fn video_cdp_js_uses_realtime_speed() {
         let js = js_start_video_quest("qid", 100, 0.0);
-        assert!(js.contains("const speed = 1;"));
-        assert!(js.contains("const interval = 1;"));
+        let timing = cdp_video_timing();
+        assert_eq!(timing.speed, timing.interval);
+        assert!(js.contains(&format!("const speed = {};", timing.speed)));
+        assert!(js.contains(&format!("const interval = {};", timing.interval)));
         assert!(!js.contains("const speed = 7;"));
     }
 
@@ -3749,5 +3849,8 @@ mod tests {
     fn cleanup_js_restores_real_games_instead_of_empty_list() {
         assert!(JS_CLEANUP_SPOOF.contains("games: remaining"));
         assert!(!JS_CLEANUP_SPOOF.contains("games: []"));
+        assert!(JS_CLEANUP_SPOOF.contains(r#"__" + "dqh_cdp""#));
+        assert!(JS_CLEANUP_SPOOF.contains("^__n[0-9a-f]{10}$"));
+        assert!(JS_VERIFY_CLEANUP_STATE.contains("^__n[0-9a-f]{10}$"));
     }
 }

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -14,6 +14,11 @@ use tauri::Emitter;
 use tokio::time::{sleep, sleep_until, Instant};
 
 use crate::cdp_client;
+use crate::cdp_game_spoof::{
+    align_play_activity_heartbeat_secs, cdp_video_timeout_secs, cdp_video_timing,
+    cleanup_verify_from_json, cleanup_verify_is_clean, path_templates, with_bridge, DetectableOs,
+    SimulatedProcessHint,
+};
 use crate::models::PlayActivityHeartbeatStatus;
 
 const QUEST_HOME_URL: &str = "https://discord.com/quest-home";
@@ -35,7 +40,7 @@ const QUEST_WARMUP_RESTORE_SETTLE_MS: u64 = 800;
 const JS_INIT_QUEST_MODULES: &str = r#"
 (async () => {
     try {
-        const DQH_INIT_VERSION = 4;
+        const DQH_INIT_VERSION = 6;
         if (window.__dqh_cdp && window.__dqh_cdp.initialized && window.__dqh_cdp._initVersion === DQH_INIT_VERSION) {
             return JSON.stringify({ success: true, cached: true });
         }
@@ -77,9 +82,16 @@ const JS_INIT_QUEST_MODULES: &str = r#"
                             modules.ApplicationStreamingStore = val;
                         }
 
-                        // RunningGameStore: direct access to getRunningGames (gist does NOT use __proto__)
-                        if (!modules.RunningGameStore && val?.getRunningGames) {
-                            modules.RunningGameStore = val;
+                        // RunningGameStore: Flux store whose getRunningGames() returns an
+                        // Array. Dozens of i18n modules expose a getRunningGames function
+                        // that returns {locale, ast}; those must not win.
+                        if (!modules.RunningGameStore && typeof val?.getRunningGames === "function") {
+                            try {
+                                const games = val.getRunningGames();
+                                if (Array.isArray(games)) {
+                                    modules.RunningGameStore = val;
+                                }
+                            } catch(e) {}
                         }
 
                         // QuestsStore: __proto__ has getQuest
@@ -138,15 +150,21 @@ const JS_INIT_QUEST_MODULES: &str = r#"
             return JSON.stringify({ success: false, error: "Missing modules: " + missing.join(", ") + " (scanned " + scanned + " modules, " + apiCandidates.length + " API candidates, " + apiTestedCount + " tested)" });
         }
 
-        window.__dqh_cdp = {
-            ...modules,
-            initialized: true,
-            _initVersion: DQH_INIT_VERSION,
-            // Save original functions for cleanup
+        Object.defineProperty(window, "__dqh_cdp", {
+            value: {
+                ...modules,
+                initialized: true,
+                _initVersion: DQH_INIT_VERSION,
+                // Save original functions for cleanup
             _origGetRunningGames: modules.RunningGameStore.getRunningGames,
             _origGetGameForPID: modules.RunningGameStore.getGameForPID || null,
+            _origGetVisibleRunningGames: modules.RunningGameStore.getVisibleRunningGames || null,
             _origGetStreamerActiveStreamMetadata: modules.ApplicationStreamingStore.getStreamerActiveStreamMetadata
-        };
+            },
+            writable: true,
+            configurable: true,
+            enumerable: false
+        });
 
         return JSON.stringify({ success: true, cached: false, apiCandidates: apiCandidates.length, apiTested: apiTestedCount });
     } catch (e) {
@@ -264,12 +282,37 @@ fn js_play_activity_status(quest_id: &str) -> String {
 
 /// Generate JS to spoof a running game in RunningGameStore.
 ///
-/// Overrides `getRunningGames()` to return an array containing the spoofed game,
-/// then dispatches `RUNNING_GAMES_CHANGE` so Discord's heartbeat system picks it up.
+/// Merges the spoofed game into the real scanner list, then dispatches
+/// `RUNNING_GAMES_CHANGE` so Discord's heartbeat system picks it up.
 fn js_spoof_play_game(app_id: &str, app_name: &str) -> String {
-    // Safely escape values for embedding in JS string literals
+    js_spoof_play_game_for(
+        app_id,
+        app_name,
+        DetectableOs::from_host(),
+        crate::game_simulator::simulated_process_hints(),
+    )
+}
+
+fn js_spoof_play_game_for(
+    app_id: &str,
+    app_name: &str,
+    host_os: DetectableOs,
+    process_hints: Vec<SimulatedProcessHint>,
+) -> String {
     let safe_app_id = serde_json::to_string(app_id).unwrap_or_else(|_| "\"\"".to_string());
     let safe_app_name = serde_json::to_string(app_name).unwrap_or_else(|_| "\"\"".to_string());
+    let host_os_json = serde_json::to_string(host_os.as_api_tag()).unwrap_or_else(|_| "\"win32\"".to_string());
+    let os_priority_json = serde_json::to_string(host_os.cdp_executable_os_priority())
+        .unwrap_or_else(|_| "[\"win32\"]".to_string());
+    let templates = path_templates(host_os);
+    let path_templates_json = serde_json::json!({
+        "cmdLine": templates.cmd_line,
+        "exePath": templates.exe_path,
+    })
+    .to_string();
+    let hints_json = serde_json::to_string(&process_hints).unwrap_or_else(|_| "[]".to_string());
+    let unix_host = if host_os.is_unix() { "true" } else { "false" };
+
     format!(
         r#"
 (async () => {{
@@ -277,61 +320,124 @@ fn js_spoof_play_game(app_id: &str, app_name: &str) -> String {
         const dqh = window.__dqh_cdp;
         if (!dqh || !dqh.initialized) return JSON.stringify({{ success: false, error: "Modules not initialized" }});
 
-        const pid = Math.floor(Math.random() * 30000) + 1000;
+        const hostOs = {host_os_json};
+        const osPriority = {os_priority_json};
+        const pathTemplates = {path_templates_json};
+        const processHints = {hints_json};
+        const unixHost = {unix_host};
+
+        function sanitizeApp(name) {{
+            return String(name || "Game").replace(/[\/\\:*?"<>|]/g, " ").replace(/\s+/g, " ").trim();
+        }}
+        function normalizeExe(raw) {{
+            let file = String(raw || "").replace(/^>+/, "");
+            file = file.split(/[\/\\]/).pop() || file;
+            if (unixHost && /\.exe$/i.test(file)) file = file.replace(/\.exe$/i, "");
+            return file;
+        }}
+        function appSlug(app) {{
+            return app.toLowerCase().split(/\s+/).filter(Boolean).join("-");
+        }}
+        function render(template, app, exe) {{
+            return String(template)
+                .split("{{app}}").join(app)
+                .split("{{app_lower}}").join(app.toLowerCase())
+                .split("{{app_slug}}").join(appSlug(app))
+                .split("{{exe}}").join(exe);
+        }}
+        function mergeFake(games, fake) {{
+            const list = Array.isArray(games) ? games.filter(g => g && g.id !== fake.id && g.pid !== fake.pid) : [];
+            list.push(fake);
+            return list;
+        }}
+
         const applicationId = {safe_app_id};
         const applicationName = {safe_app_name};
-
-        // Fetch real exe info from Discord's public API (same as gist)
-        let exeName = applicationName.replace(/[\/\\:*?"<>|]/g, "") + ".exe";
+        let exeName = unixHost ? sanitizeApp(applicationName) : sanitizeApp(applicationName) + ".exe";
         let allExeNames = [];
+        let selectedOs = null;
         let appDataDebug = null;
         try {{
             const res = await dqh.api.get({{ url: "/applications/public?application_ids=" + applicationId }});
             if (res && res.body && res.body[0]) {{
                 const appData = res.body[0];
                 appDataDebug = appData.name;
-                const allExes = (appData.executables || []).filter(x => x.os === "win32");
-                allExeNames = allExes.map(x => x.name);
-                const exe = allExes[0];
-                if (exe && exe.name) {{
-                    exeName = exe.name.replace(">","");
+                const allExes = appData.executables || [];
+                allExeNames = allExes.map(x => x && x.name).filter(Boolean);
+                let selected = null;
+                for (const os of osPriority) {{
+                    selected = allExes.find(x => x && x.os === os && x.name);
+                    if (selected) {{ selectedOs = os; break; }}
+                }}
+                if (!selected && allExes[0] && allExes[0].name) {{
+                    selected = allExes[0];
+                    selectedOs = allExes[0].os || null;
+                }}
+                if (selected && selected.name) {{
+                    exeName = normalizeExe(selected.name);
                 }}
             }}
         }} catch(e) {{}}
 
+        exeName = normalizeExe(exeName);
+        const hint = (processHints || []).find(h => {{
+            const base = String(h.exePath || "").split(/[\/\\]/).pop() || "";
+            return (h.exeName && h.exeName.toLowerCase() === exeName.toLowerCase())
+                || base.toLowerCase() === exeName.toLowerCase();
+        }});
+        const builtCmd = render(pathTemplates.cmdLine, sanitizeApp(applicationName), exeName);
+        const builtPath = render(pathTemplates.exePath, sanitizeApp(applicationName), exeName);
+        const pid = hint && hint.pid ? hint.pid : Math.floor(Math.random() * 30000) + 1000;
         const fakeGame = {{
-            cmdLine: "C:\\Program Files\\" + applicationName + "\\" + exeName,
-            exeName: exeName,
-            exePath: "c:/program files/" + applicationName.toLowerCase() + "/" + exeName,
-            hidden: false,
-            isLauncher: false,
             id: applicationId,
+            nativeProcessObserverId: pid,
             name: applicationName,
+            origGameName: applicationName,
+            processName: applicationName,
+            hidden: false,
+            elevated: false,
+            sandboxed: false,
+            lastFocused: Date.now(),
+            exePath: hint && hint.exePath ? hint.exePath : builtPath,
+            exeName: exeName,
+            cmdLine: hint && hint.cmdLine ? hint.cmdLine : builtCmd,
             pid: pid,
             pidPath: [pid],
-            processName: applicationName,
-            start: Date.now()
+            windowHandle: null,
+            fullscreenType: null,
+            isLauncher: false,
+            distributor: undefined,
+            sku: undefined,
+            gameMetadata: undefined,
+            executableFingerprint: undefined
         }};
 
-        // Call original function WITH proper this-context (unlike dqh._origGetRunningGames())
         let realGames = [];
         try {{ realGames = dqh._origGetRunningGames.call(dqh.RunningGameStore); }} catch(e) {{
             try {{ realGames = dqh._origGetRunningGames(); }} catch(e2) {{ realGames = []; }}
         }}
-        const fakeGames = [fakeGame];
+        if (!Array.isArray(realGames)) realGames = [];
 
-        // Override store methods directly (same pattern as gist)
-        dqh.RunningGameStore.getRunningGames = () => fakeGames;
-        dqh.RunningGameStore.getGameForPID = (p) => fakeGames.find(x => x.pid === p);
-
-        // Save fakeGame so cleanup can properly remove it
         dqh._fakeGame = fakeGame;
         dqh._spoofActive = true;
 
-        // Gist-style broad patch: re-scan ALL webpack modules and override every
-        // getRunningGames reference found. Discord holds multiple module copies —
-        // patching only the one found during init scan is not always sufficient.
-        let patchCount = 1; // already patched dqh.RunningGameStore above
+        function patchedGetRunningGames() {{
+            let games = [];
+            try {{ games = dqh._origGetRunningGames.call(dqh.RunningGameStore); }} catch(e) {{
+                try {{ games = dqh._origGetRunningGames(); }} catch(e2) {{ games = []; }}
+            }}
+            return mergeFake(games, dqh._fakeGame);
+        }}
+        function patchedGetGameForPID(p) {{
+            return patchedGetRunningGames().find(x => x.pid === p);
+        }}
+        dqh.RunningGameStore.getRunningGames = patchedGetRunningGames;
+        dqh.RunningGameStore.getGameForPID = patchedGetGameForPID;
+        if (typeof dqh.RunningGameStore.getVisibleRunningGames === "function") {{
+            dqh.RunningGameStore.getVisibleRunningGames = patchedGetRunningGames;
+        }}
+
+        let patchCount = 1;
         const broadPatched = [];
         try {{
             const wpReq = webpackChunkdiscord_app.push([[Symbol()], {{}}, r => r]);
@@ -344,11 +450,16 @@ fn js_spoof_play_game(app_id: &str, app_name: &str) -> String {
                         try {{
                             const val = exp[key];
                             if (val && val !== dqh.RunningGameStore && typeof val.getRunningGames === 'function') {{
+                                let sample = null;
+                                try {{ sample = val.getRunningGames(); }} catch(e) {{ continue; }}
+                                if (!Array.isArray(sample)) continue;
                                 const origFn = val.getRunningGames;
                                 const origPidFn = typeof val.getGameForPID === 'function' ? val.getGameForPID : null;
-                                val.getRunningGames = () => fakeGames;
-                                if (origPidFn) val.getGameForPID = (p) => fakeGames.find(x => x.pid === p);
-                                broadPatched.push({{ val, origFn, origPidFn }});
+                                const origVisibleFn = typeof val.getVisibleRunningGames === 'function' ? val.getVisibleRunningGames : null;
+                                val.getRunningGames = patchedGetRunningGames;
+                                if (origPidFn) val.getGameForPID = patchedGetGameForPID;
+                                if (origVisibleFn) val.getVisibleRunningGames = patchedGetRunningGames;
+                                broadPatched.push({{ val, origFn, origPidFn, origVisibleFn }});
                                 patchCount++;
                             }}
                         }} catch(e) {{}}
@@ -358,38 +469,30 @@ fn js_spoof_play_game(app_id: &str, app_name: &str) -> String {
         }} catch(e) {{}}
         dqh._broadPatched = broadPatched;
 
-        // CRITICAL: Hook FluxDispatcher.dispatch to intercept RUNNING_GAMES_CHANGE events.
-        // Discord's native game scanner runs periodically and dispatches RUNNING_GAMES_CHANGE
-        // with the REAL (empty) process list. This clears our fake game from the heartbeat
-        // manager's state, preventing quest progress. By hooking dispatch, we ensure our
-        // fake game is always present in any RUNNING_GAMES_CHANGE event, even those
-        // dispatched by the native scanner.
         dqh._dispatchInterceptCount = 0;
         if (!dqh._origDispatch) {{
             const origDispatch = dqh.FluxDispatcher.dispatch.bind(dqh.FluxDispatcher);
             dqh._origDispatch = origDispatch;
             dqh.FluxDispatcher.dispatch = function(event) {{
                 if (event && event.type === "RUNNING_GAMES_CHANGE" && dqh._fakeGame && dqh._spoofActive) {{
-                    if (!event.games) event.games = [];
-                    const hasFake = event.games.some(g => g.id === dqh._fakeGame.id || g.pid === dqh._fakeGame.pid);
-                    if (!hasFake) {{
-                        // Native scanner cleared our fake game — re-inject it
-                        event.games.push(dqh._fakeGame);
-                        if (!event.added) event.added = [];
+                    const before = Array.isArray(event.games) ? event.games.length : 0;
+                    event.games = mergeFake(event.games, dqh._fakeGame);
+                    if (!event.added) event.added = [];
+                    if (!event.added.some(g => g && (g.id === dqh._fakeGame.id || g.pid === dqh._fakeGame.pid))) {{
                         event.added.push(dqh._fakeGame);
-                        if (event.removed) {{
-                            event.removed = event.removed.filter(g => g.id !== dqh._fakeGame.id && g.pid !== dqh._fakeGame.pid);
-                        }}
-                        dqh._dispatchInterceptCount++;
                     }}
+                    if (event.removed) {{
+                        event.removed = event.removed.filter(g => g && g.id !== dqh._fakeGame.id && g.pid !== dqh._fakeGame.pid);
+                    }}
+                    if (event.games.length !== before) dqh._dispatchInterceptCount++;
                 }}
                 return origDispatch(event);
             }};
         }}
 
-        dqh.FluxDispatcher.dispatch({{ type: "RUNNING_GAMES_CHANGE", removed: realGames, added: [fakeGame], games: fakeGames }});
+        const mergedGames = mergeFake(realGames, fakeGame);
+        dqh.FluxDispatcher.dispatch({{ type: "RUNNING_GAMES_CHANGE", removed: [], added: [fakeGame], games: mergedGames }});
 
-        // Subscribe to heartbeat success events (same as gist) to track progress
         dqh._lastProgress = 0;
         dqh._completed = false;
         dqh._heartbeatCount = 0;
@@ -416,7 +519,6 @@ fn js_spoof_play_game(app_id: &str, app_name: &str) -> String {
         dqh._heartbeatFn = heartbeatFn;
         dqh.FluxDispatcher.subscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", heartbeatFn);
 
-        // Also subscribe to heartbeat failure for diagnostics
         dqh._lastHeartbeatFailure = null;
         let heartbeatFailFn = data => {{
             try {{
@@ -428,7 +530,7 @@ fn js_spoof_play_game(app_id: &str, app_name: &str) -> String {
         dqh._heartbeatFailFn = heartbeatFailFn;
         dqh.FluxDispatcher.subscribe("QUESTS_SEND_HEARTBEAT_FAILURE", heartbeatFailFn);
 
-        return JSON.stringify({{ success: true, pid: pid, patchCount: patchCount, exeName: exeName, allExeNames: allExeNames, appDataName: appDataDebug, realGamesCount: realGames.length }});
+        return JSON.stringify({{ success: true, pid: pid, patchCount: patchCount, exeName: exeName, allExeNames: allExeNames, appDataName: appDataDebug, realGamesCount: realGames.length, mergedCount: mergedGames.length, hostOs: hostOs, selectedOs: selectedOs, usedHint: !!hint }});
     }} catch (e) {{
         return JSON.stringify({{ success: false, error: String(e) }});
     }}
@@ -503,6 +605,7 @@ fn js_spoof_stream(app_id: &str) -> String {
 /// Mirrors the gist's time-bound approach: Discord validates that the
 /// submitted timestamp doesn't exceed `(now - enrolledAt) + maxFuture`.
 fn js_start_video_quest(quest_id: &str, seconds_needed: u32, initial_seconds: f64) -> String {
+    let timing = cdp_video_timing();
     format!(
         r#"
 (() => {{
@@ -532,9 +635,9 @@ fn js_start_video_quest(quest_id: &str, seconds_needed: u32, initial_seconds: f6
             try {{
                 let secondsDone = {initial_seconds};
                 const enrolledAt = new Date(quest.userStatus.enrolledAt).getTime();
-                const maxFuture = 10;
-                const speed = 7;
-                const interval = 1;
+        const speed = {video_speed};
+        const interval = {video_interval};
+        const maxFuture = {video_max_future};
                 let completed = false;
                 let consecutiveErrors = 0;
                 const maxErrors = 10;
@@ -649,7 +752,10 @@ fn js_start_video_quest(quest_id: &str, seconds_needed: u32, initial_seconds: f6
 "#,
         quest_id = quest_id,
         seconds_needed = seconds_needed,
-        initial_seconds = initial_seconds
+        initial_seconds = initial_seconds,
+        video_speed = timing.speed,
+        video_interval = timing.interval,
+        video_max_future = timing.max_future
     )
 }
 
@@ -784,6 +890,9 @@ const JS_CLEANUP_SPOOF: &str = r#"
                 dqh.RunningGameStore.getGameForPID = undefined;
             }
         }
+        if (typeof dqh._origGetVisibleRunningGames === "function") {
+            dqh.RunningGameStore.getVisibleRunningGames = dqh._origGetVisibleRunningGames;
+        }
         if (dqh._origGetStreamerActiveStreamMetadata) {
             dqh.ApplicationStreamingStore.getStreamerActiveStreamMetadata = dqh._origGetStreamerActiveStreamMetadata;
         }
@@ -796,6 +905,7 @@ const JS_CLEANUP_SPOOF: &str = r#"
                 try {
                     patch.val.getRunningGames = patch.origFn;
                     if (patch.origPidFn) patch.val.getGameForPID = patch.origPidFn;
+                    if (patch.origVisibleFn) patch.val.getVisibleRunningGames = patch.origVisibleFn;
                 } catch(e) {}
             }
         }
@@ -808,9 +918,22 @@ const JS_CLEANUP_SPOOF: &str = r#"
             dqh.FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_FAILURE", dqh._heartbeatFailFn);
         }
 
-        // NOW dispatch removal event — all patches are already restored
+        // Restore originals first, then tell Discord the fake game left while
+        // keeping any real games the native scanner still sees.
+        let remaining = [];
+        try {
+            remaining = dqh._origGetRunningGames
+                ? dqh._origGetRunningGames.call(dqh.RunningGameStore)
+                : [];
+        } catch (e) {
+            remaining = [];
+        }
+        if (!Array.isArray(remaining)) remaining = [];
+        if (dqh._fakeGame) {
+            remaining = remaining.filter(g => g && g.id !== dqh._fakeGame.id && g.pid !== dqh._fakeGame.pid);
+        }
         if (dqh.FluxDispatcher && dqh._fakeGame) {
-            dqh.FluxDispatcher.dispatch({ type: "RUNNING_GAMES_CHANGE", removed: [dqh._fakeGame], added: [], games: [] });
+            dqh.FluxDispatcher.dispatch({ type: "RUNNING_GAMES_CHANGE", removed: [dqh._fakeGame], added: [], games: remaining });
         }
 
         delete window.__dqh_cdp;
@@ -1110,8 +1233,9 @@ async fn cdp_execute_json_on_all_targets(
     timeout_secs: u64,
     operation: &str,
 ) -> Result<CdpJsonExecutionSummary> {
+    let rewritten = with_bridge(js_code);
     let results =
-        cdp_client::execute_js_via_all_discord_targets(port, js_code, await_promise, timeout_secs)
+        cdp_client::execute_js_via_all_discord_targets(port, &rewritten, await_promise, timeout_secs)
             .await
             .with_context(|| {
                 format!("Failed to execute CDP {} across Discord targets", operation)
@@ -1406,7 +1530,7 @@ fn parse_play_activity_cdp_status(raw: &str) -> Result<PlayActivityHeartbeatStat
 
 async fn cdp_init_modules_on_primary(port: u16) -> Result<()> {
     let raw =
-        cdp_client::execute_js_via_primary_discord_target(port, JS_INIT_QUEST_MODULES, true, 60)
+        cdp_client::execute_js_via_primary_discord_target(port, &with_bridge(JS_INIT_QUEST_MODULES), true, 60)
             .await
             .context("Failed to initialize Discord modules on the primary CDP target")?;
     let parsed: serde_json::Value =
@@ -1431,7 +1555,7 @@ async fn cdp_send_play_activity_heartbeat(
     terminal: bool,
 ) -> Result<PlayActivityHeartbeatStatus> {
     let js = js_play_activity_heartbeat(quest_id, application_id, terminal);
-    let raw = cdp_client::execute_js_via_primary_discord_target(port, &js, true, 20)
+    let raw = cdp_client::execute_js_via_primary_discord_target(port, &with_bridge(&js), true, 20)
         .await
         .context("Failed to execute PLAY_ACTIVITY heartbeat on the primary CDP target")?;
     parse_play_activity_cdp_status(&raw)
@@ -1442,22 +1566,24 @@ async fn cdp_get_play_activity_status(
     quest_id: &str,
 ) -> Result<PlayActivityHeartbeatStatus> {
     let js = js_play_activity_status(quest_id);
-    let raw = cdp_client::execute_js_via_primary_discord_target(port, &js, true, 20)
+    let raw = cdp_client::execute_js_via_primary_discord_target(port, &with_bridge(&js), true, 20)
         .await
         .context("Failed to query PLAY_ACTIVITY status on the primary CDP target")?;
     parse_play_activity_cdp_status(&raw)
 }
 
-/// Cleanup spoofed stores via CDP.
-async fn cdp_cleanup(port: u16) {
+/// Cleanup spoofed stores via CDP and verify every Discord page target is clean.
+async fn cdp_cleanup(port: u16) -> Result<()> {
     use crate::logger::{log, LogCategory, LogLevel};
 
-    // Try cleanup up to 2 times — CDP connection can be flaky
-    for attempt in 1..=2 {
+    const MAX_ATTEMPTS: u32 = 5;
+    let cleanup_js = with_bridge(JS_CLEANUP_SPOOF);
+    let verify_js = with_bridge(JS_VERIFY_CLEANUP_STATE);
+
+    for attempt in 1..=MAX_ATTEMPTS {
         let mut cleanup_success_count = 0usize;
 
-        match cdp_client::execute_js_via_all_discord_targets(port, JS_CLEANUP_SPOOF, false, 5).await
-        {
+        match cdp_client::execute_js_via_all_discord_targets(port, &cleanup_js, false, 5).await {
             Ok(results) => {
                 let mut error_count = 0usize;
 
@@ -1521,15 +1647,7 @@ async fn cdp_cleanup(port: u16) {
             }
         }
 
-        // Verify cleanup state across all page targets.
-        match cdp_client::execute_js_via_all_discord_targets(
-            port,
-            JS_VERIFY_CLEANUP_STATE,
-            false,
-            5,
-        )
-        .await
-        {
+        match cdp_client::execute_js_via_all_discord_targets(port, &verify_js, false, 5).await {
             Ok(results) => {
                 let mut verify_checked = 0usize;
                 let mut verify_dirty = 0usize;
@@ -1550,9 +1668,7 @@ async fn cdp_cleanup(port: u16) {
 
                     let raw = item.result.unwrap_or_default();
                     let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap_or_default();
-                    let verify_success = parsed.get("success") == Some(&serde_json::json!(true));
-
-                    if !verify_success {
+                    let Some(verify) = cleanup_verify_from_json(&parsed) else {
                         verify_dirty += 1;
                         log(LogLevel::Warn, LogCategory::TokenExtraction,
                             &format!(
@@ -1562,36 +1678,10 @@ async fn cdp_cleanup(port: u16) {
                             None,
                         );
                         continue;
-                    }
+                    };
 
                     verify_checked += 1;
-                    let dqh_present = parsed
-                        .get("dqhPresent")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    let spoof_active = parsed
-                        .get("spoofActive")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    let fake_game_present = parsed
-                        .get("fakeGamePresent")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    let has_dispatch_hook = parsed
-                        .get("hasDispatchHook")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    let broad_patch_count = parsed
-                        .get("broadPatchCount")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0);
-
-                    let target_dirty = dqh_present
-                        || spoof_active
-                        || fake_game_present
-                        || has_dispatch_hook
-                        || broad_patch_count > 0;
-                    if target_dirty {
+                    if !cleanup_verify_is_clean(&verify) {
                         verify_dirty += 1;
                         log(LogLevel::Warn, LogCategory::TokenExtraction,
                             &format!(
@@ -1599,11 +1689,11 @@ async fn cdp_cleanup(port: u16) {
                                 attempt,
                                 item.target_title,
                                 item.target_url,
-                                dqh_present,
-                                spoof_active,
-                                fake_game_present,
-                                has_dispatch_hook,
-                                broad_patch_count
+                                verify.dqh_present,
+                                verify.spoof_active,
+                                verify.fake_game_present,
+                                verify.has_dispatch_hook,
+                                verify.broad_patch_count
                             ),
                             None,
                         );
@@ -1618,7 +1708,7 @@ async fn cdp_cleanup(port: u16) {
                         ),
                         None,
                     );
-                    return;
+                    return Ok(());
                 }
 
                 log(LogLevel::Warn, LogCategory::TokenExtraction,
@@ -1642,17 +1732,12 @@ async fn cdp_cleanup(port: u16) {
             }
         }
 
-        if attempt < 2 {
+        if attempt < MAX_ATTEMPTS {
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
     }
 
-    log(
-        LogLevel::Error,
-        LogCategory::TokenExtraction,
-        "CDP cleanup failed after all retries — spoof may still be active in Discord!",
-        None,
-    );
+    anyhow::bail!("CDP cleanup failed after all retries — spoof may still be active in Discord")
 }
 
 /// Poll quest progress via CDP. Uses direct API call for fresh data.
@@ -1816,7 +1901,7 @@ pub async fn complete_play_quest_via_cdp(
 
     // Defensive pre-cleanup: prevent stale spoof state from a previous run from leaking
     // into the new quest session.
-    cdp_cleanup(port).await;
+    let _ = cdp_cleanup(port).await;
     cdp_warmup_quest_route(port).await;
 
     // 1. Init modules
@@ -1830,7 +1915,7 @@ pub async fn complete_play_quest_via_cdp(
         match cdp_execute_json_on_all_targets(port, &js, true, 15, "play quest spoof").await {
             Ok(summary) => summary,
             Err(err) => {
-                cdp_cleanup(port).await;
+                let _ = cdp_cleanup(port).await;
                 return Err(err);
             }
         };
@@ -1892,7 +1977,7 @@ pub async fn complete_play_quest_via_cdp(
             _ = sleep(poll_interval) => {},
             _ = cancel_rx.recv() => {
                 log(LogLevel::Info, LogCategory::TokenExtraction, "CDP play quest cancelled", None);
-                cdp_cleanup(port).await;
+                let _ = cdp_cleanup(port).await;
                 let _ = app_handle.emit("quest-stopped", ());
                 return Ok(());
             }
@@ -1968,7 +2053,7 @@ pub async fn complete_play_quest_via_cdp(
                 "CDP play quest completed!",
                 None,
             );
-            cdp_cleanup(port).await;
+            let _ = cdp_cleanup(port).await;
             let _ = app_handle.emit("quest-complete", ());
             return Ok(());
         }
@@ -1999,7 +2084,7 @@ pub async fn complete_stream_quest_via_cdp(
     );
 
     // Defensive pre-cleanup: ensure previous spoof state is removed before applying new patches.
-    cdp_cleanup(port).await;
+    let _ = cdp_cleanup(port).await;
     cdp_warmup_quest_route(port).await;
 
     // 1. Init modules
@@ -2013,7 +2098,7 @@ pub async fn complete_stream_quest_via_cdp(
         match cdp_execute_json_on_all_targets(port, &js, false, 10, "stream quest spoof").await {
             Ok(summary) => summary,
             Err(err) => {
-                cdp_cleanup(port).await;
+                let _ = cdp_cleanup(port).await;
                 return Err(err);
             }
         };
@@ -2054,7 +2139,7 @@ pub async fn complete_stream_quest_via_cdp(
             _ = sleep(poll_interval) => {},
             _ = cancel_rx.recv() => {
                 log(LogLevel::Info, LogCategory::TokenExtraction, "CDP stream quest cancelled", None);
-                cdp_cleanup(port).await;
+                let _ = cdp_cleanup(port).await;
                 let _ = app_handle.emit("quest-stopped", ());
                 return Ok(());
             }
@@ -2130,7 +2215,7 @@ pub async fn complete_stream_quest_via_cdp(
                 "CDP stream quest completed!",
                 None,
             );
-            cdp_cleanup(port).await;
+            let _ = cdp_cleanup(port).await;
             let _ = app_handle.emit("quest-complete", ());
             return Ok(());
         }
@@ -2163,7 +2248,7 @@ pub async fn complete_video_quest_via_cdp(
     );
 
     // Defensive pre-cleanup for cross-quest consistency.
-    cdp_cleanup(port).await;
+    let _ = cdp_cleanup(port).await;
     cdp_warmup_quest_route(port).await;
 
     // 1. Init modules
@@ -2204,7 +2289,7 @@ pub async fn complete_video_quest_via_cdp(
     // 3. Poll progress until the JS loop finishes (videoRunning=false) or quest completes
     let poll_interval = Duration::from_secs(5);
     let max_duration = Duration::from_secs(
-        ((seconds_needed as f64 - initial_progress).max(0.0) / 7.0 * 2.0) as u64 + 300,
+        cdp_video_timeout_secs(seconds_needed, initial_progress),
     );
     let start_time = std::time::Instant::now();
 
@@ -2267,6 +2352,7 @@ pub async fn complete_video_quest_via_cdp(
                     );
                     let _ = app_handle.emit("quest-progress", 100.0f64);
                     let _ = app_handle.emit("quest-complete", ());
+                    let _ = cdp_cleanup(port).await;
                     return Ok(());
                 }
             }
@@ -2331,6 +2417,7 @@ pub async fn complete_video_quest_via_cdp(
                                     let _ = app_handle.emit("quest-progress", progress_pct);
                                     let _ = app_handle.emit("quest-error", "Video quest finished but server has not confirmed completion. Please check quest status in Discord.".to_string());
                                 }
+                                let _ = cdp_cleanup(port).await;
                                 return Ok(());
                             } else {
                                 let error = parsed.get("error")
@@ -2949,7 +3036,7 @@ async fn confirm_play_activity_via_cdp(
             tokio::select! {
                 _ = sleep(Duration::from_secs(2)) => {},
                 _ = cancel_rx.recv() => {
-                    cdp_cleanup(port).await;
+                    let _ = cdp_cleanup(port).await;
                     let _ = app_handle.emit("quest-stopped", ());
                     return Ok(());
                 }
@@ -2957,7 +3044,7 @@ async fn confirm_play_activity_via_cdp(
         }
     }
 
-    cdp_cleanup(port).await;
+    let _ = cdp_cleanup(port).await;
     if confirmed {
         let _ = app_handle.emit("quest-progress", 100.0f64);
         let _ = app_handle.emit("quest-complete", ());
@@ -2994,10 +3081,10 @@ pub async fn complete_play_activity_via_cdp(
         anyhow::bail!("PLAY_ACTIVITY intervals must be greater than zero");
     }
 
-    cdp_cleanup(port).await;
+    let _ = cdp_cleanup(port).await;
     cdp_warmup_quest_route(port).await;
     if let Err(error) = cdp_init_modules_on_primary(port).await {
-        cdp_cleanup(port).await;
+        let _ = cdp_cleanup(port).await;
         return Err(error.context("Failed to initialize CDP modules for PLAY_ACTIVITY"));
     }
 
@@ -3006,6 +3093,7 @@ pub async fn complete_play_activity_via_cdp(
         .ceil() as u64;
     let max_duration = Duration::from_secs(remaining_seconds.saturating_add(TIMEOUT_GRACE_SECS));
     let timeout_at = Instant::now() + max_duration;
+    let heartbeat_interval_secs = align_play_activity_heartbeat_secs(heartbeat_interval_secs);
     let heartbeat_interval = Duration::from_secs(heartbeat_interval_secs);
     let progress_polling_interval = Duration::from_secs(progress_polling_interval_secs);
     let mut next_progress_poll = Instant::now() + progress_polling_interval;
@@ -3026,7 +3114,7 @@ pub async fn complete_play_activity_via_cdp(
             if session_started {
                 let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
             }
-            cdp_cleanup(port).await;
+            let _ = cdp_cleanup(port).await;
             let _ = app_handle.emit("quest-stopped", ());
             return Ok(());
         }
@@ -3035,7 +3123,7 @@ pub async fn complete_play_activity_via_cdp(
             if session_started {
                 let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
             }
-            cdp_cleanup(port).await;
+            let _ = cdp_cleanup(port).await;
             anyhow::bail!("PLAY_ACTIVITY timed out before Discord confirmed completion");
         }
 
@@ -3068,7 +3156,7 @@ pub async fn complete_play_activity_via_cdp(
                     if session_started {
                         let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
                     }
-                    cdp_cleanup(port).await;
+                    let _ = cdp_cleanup(port).await;
                     return Err(error.context("CDP PLAY_ACTIVITY heartbeat failed three times"));
                 }
 
@@ -3079,7 +3167,7 @@ pub async fn complete_play_activity_via_cdp(
                         if session_started {
                             let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
                         }
-                        cdp_cleanup(port).await;
+                        let _ = cdp_cleanup(port).await;
                         let _ = app_handle.emit("quest-stopped", ());
                         return Ok(());
                     }
@@ -3107,7 +3195,7 @@ pub async fn complete_play_activity_via_cdp(
                 _ = sleep_until(wake_at) => {},
                 _ = cancel_rx.recv() => {
                     let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
-                    cdp_cleanup(port).await;
+                    let _ = cdp_cleanup(port).await;
                     let _ = app_handle.emit("quest-stopped", ());
                     return Ok(());
                 }
@@ -3116,7 +3204,7 @@ pub async fn complete_play_activity_via_cdp(
             let now = Instant::now();
             if now >= timeout_at {
                 let _ = cdp_send_play_activity_heartbeat(port, &quest_id, None, true).await;
-                cdp_cleanup(port).await;
+                let _ = cdp_cleanup(port).await;
                 anyhow::bail!("PLAY_ACTIVITY timed out before Discord confirmed completion");
             }
 
@@ -3568,6 +3656,37 @@ mod tests {
     }
 
     #[test]
+    fn init_js_requires_getrunninggames_to_return_array() {
+        assert!(JS_INIT_QUEST_MODULES.contains("Array.isArray(games)"));
+        assert!(JS_INIT_QUEST_MODULES.contains("const games = val.getRunningGames();"));
+        assert!(!JS_INIT_QUEST_MODULES.contains(
+            "if (!modules.RunningGameStore && val?.getRunningGames)"
+        ));
+    }
+
+    #[test]
+    fn play_spoof_js_includes_live_scanner_fields() {
+        let js = js_spoof_play_game_for("123", "Cool Game", DetectableOs::Win32, Vec::new());
+        for field in [
+            "nativeProcessObserverId",
+            "origGameName",
+            "elevated",
+            "sandboxed",
+            "lastFocused",
+            "windowHandle",
+            "fullscreenType",
+            "getVisibleRunningGames",
+            "distributor",
+            "sku",
+            "gameMetadata",
+            "executableFingerprint",
+        ] {
+            assert!(js.contains(field), "missing live scanner field {field}");
+        }
+        assert!(js.contains("if (!Array.isArray(sample)) continue"));
+    }
+
+    #[test]
     fn test_activity_init_allows_getquest_mismatch_before_start() {
         let js = js_init_activity_quest("151912345678908740");
 
@@ -3589,5 +3708,46 @@ mod tests {
                 .count(),
             2
         );
+    }
+
+    #[test]
+    fn play_spoof_js_on_linux_and_macos_uses_unix_paths() {
+        for os in [DetectableOs::Linux, DetectableOs::Darwin] {
+            let js = js_spoof_play_game_for("123", "Cool Game", os, Vec::new());
+            assert!(!js.contains("Program Files"), "{os:?} leaked Windows paths");
+            assert!(js.contains("mergeFake"), "{os:?} must merge real running games");
+            assert!(js.contains("removed: []"), "{os:?} must not drop real games");
+            assert!(!js.contains("const fakeGames = [fakeGame]"));
+        }
+
+        let linux = js_spoof_play_game_for("123", "Cool Game", DetectableOs::Linux, Vec::new());
+        assert!(linux.contains("/opt/{app_slug}/{exe}") || linux.contains("/opt/"));
+        assert!(linux.contains("\"linux\""));
+
+        let darwin = js_spoof_play_game_for("123", "Cool Game", DetectableOs::Darwin, Vec::new());
+        assert!(darwin.contains("/Applications/"));
+        assert!(darwin.contains("\"darwin\""));
+        assert!(darwin.contains(".app/Contents/MacOS/"));
+    }
+
+    #[test]
+    fn play_spoof_js_on_windows_keeps_program_files() {
+        let js = js_spoof_play_game_for("123", "Cool Game", DetectableOs::Win32, Vec::new());
+        assert!(js.contains("Program Files"));
+        assert!(js.contains("mergeFake"));
+    }
+
+    #[test]
+    fn video_cdp_js_uses_realtime_speed() {
+        let js = js_start_video_quest("qid", 100, 0.0);
+        assert!(js.contains("const speed = 1;"));
+        assert!(js.contains("const interval = 1;"));
+        assert!(!js.contains("const speed = 7;"));
+    }
+
+    #[test]
+    fn cleanup_js_restores_real_games_instead_of_empty_list() {
+        assert!(JS_CLEANUP_SPOOF.contains("games: remaining"));
+        assert!(!JS_CLEANUP_SPOOF.contains("games: []"));
     }
 }

--- a/src-tauri/src/game_simulator.rs
+++ b/src-tauri/src/game_simulator.rs
@@ -566,6 +566,34 @@ fn untrack_running_game(executable_name: &str) {
     }
 }
 
+/// Snapshot of simulated-game processes that CDP spoof can reuse as a real PID/path.
+pub fn simulated_process_hints() -> Vec<crate::cdp_game_spoof::SimulatedProcessHint> {
+    #[cfg(target_os = "linux")]
+    {
+        let games = match RUNNING_LINUX_GAMES.lock() {
+            Ok(games) => games,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        games
+            .iter()
+            .map(|(name, game)| {
+                let path = game.executable_path.to_string_lossy().into_owned();
+                crate::cdp_game_spoof::SimulatedProcessHint {
+                    pid: game.pid,
+                    exe_name: name.clone(),
+                    exe_path: path.clone(),
+                    cmd_line: path,
+                }
+            })
+            .collect()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Vec::new()
+    }
+}
+
 /// Stop **all** tracked simulated game processes.
 ///
 /// Called on application exit to ensure no orphaned child processes are left

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod cdp_client;
+mod cdp_game_spoof;
 mod cdp_quest;
 mod discord_api;
 mod discord_cdp_commands;


### PR DESCRIPTION
## Summary
- Make CDP play-quest spoofing look like a native `RunningGameStore` update so Discord itself keeps sending signed heartbeats, instead of replacing the whole process list with a gist-shaped fake object.
- Discover the real store by requiring `getRunningGames()` to return an **Array** (current desktop webpack exposes ~56 i18n decoys that return `{locale, ast}`), merge the fake game into the live scanner list, and emit host-native paths (`win32` / `darwin`+`/Applications` / `linux`+`/opt`).
- Shrink the injection surface: session-scoped non-enumerable bridge name, restore `getVisibleRunningGames`, verify **every** Discord page target, and fail cleanup after five retries. CDP video runs at 1x; PLAY_ACTIVITY heartbeats are floored at 60s to match `discord-heartbeat-game-quest.har`.

This is the CDP status-detection fidelity work discussed on #118. Simulate-mode OS priority, AppImage process renaming, and the legacy HTTP heartbeat path are unchanged.

## Live check
Validated against a local Discord desktop client on CDP `:9223` (`Friends` / `/channels/@me`):
- Init selected the Array-returning store (56 i18n decoys skipped).
- Dummy game appeared in both `getRunningGames()` and `getVisibleRunningGames()`.
- Fake object key set matched a live Chrome non-game, including `distributor` / `sku` / `gameMetadata` / `executableFingerprint` (enumerable, `undefined`).
- Cleanup left no bridge, dispatch hook, or leftover probe process.

## Test plan
- [ ] `cargo test --lib` in `src-tauri` (76 passed locally)
- [ ] Windows CDP: start a play quest with Discord on `:9223` and confirm progress heartbeats still advance
- [ ] Confirm a real running game is still listed in Discord while spoof is active (merge, not replace)
- [ ] After stop/complete/cancel, Discord no longer shows the spoofed game and no `__dqh_cdp` / `__n*` bridge remains
- [ ] Linux/macOS: spoof paths are `/opt/...` or `/Applications/.../MacOS/...`, not `C:\Program Files`
- [ ] Optional: capture `getRunningGames()[0]` while a real detectable game is running, to confirm whether the four extra keys stay `undefined` or get values

## Summary by Sourcery

Align CDP-based play quest spoofing with Discord’s native RunningGameStore schema to preserve real scanner behavior, improve cleanup guarantees, and normalize timing for video and PLAY_ACTIVITY quests.

New Features:
- Introduce a CDP game spoof helper module that encapsulates OS-aware path templating, running-game schema alignment, heartbeat cadence control, and cleanup verification.
- Reuse simulated game processes as hints for CDP spoofed running games, providing realistic PIDs and executable paths where available.

Enhancements:
- Update running-game spoofing to merge fake games into the live scanner list, including additional fields used by Discord’s native RunningGameStore, and support getVisibleRunningGames.
- Restrict module initialization to Flux stores whose getRunningGames returns an array, avoiding i18n decoy modules with non-game payloads.
- Use a non-enumerable, session-scoped CDP bridge identifier in place of the previous global __dqh_cdp symbol and wrap all injected JS with this bridge.
- Normalize CDP video quest timing to real-time playback parameters and compute timeouts using shared helper logic.
- Refine cleanup logic to restore original store methods, preserve any real running games, and require all hooks and patches to be removed across every Discord page target before succeeding.

Tests:
- Add unit tests covering spoof JS structure, OS-specific path rendering, video timing behavior, heartbeat interval alignment, and cleanup behavior to guard against regressions in spoof fidelity and cleanup semantics.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns CDP game spoofing with Discord’s live running-game schema and strengthens cross-target cleanup verification.
- Merges spoofed games with native scanner results and adds platform-specific executable paths.
- Introduces session-scoped bridges, broader restoration checks, process hints, and revised heartbeat/video timing.
- Adds focused tests for schema fidelity, path rendering, timing, and cleanup-state verification.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until exhausted cleanup failures affect quest control flow instead of allowing completion or cancellation to proceed with stale spoof state.

Cleanup now detects and returns residual-state failures internally, but every wrapper still discards or only logs that result; cancellation further reduces cleanup to one attempt, so stale hooks, store patches, or fake games can remain after the operation reports that it stopped.

**Files Needing Attention:** src-tauri/src/cdp_quest.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/cdp_game_spoof.rs | Adds OS-aware spoof construction, timing helpers, bridge rewriting, cleanup parsing, and unit coverage. |
| src-tauri/src/cdp_quest.rs | Reworks spoof fidelity and cleanup verification, but cleanup exhaustion remains non-propagating and cancellation receives only one attempt. |
| src-tauri/src/game_simulator.rs | Exposes simulated-process metadata for constructing more realistic CDP game records. |
| src-tauri/src/lib.rs | Registers the new CDP game-spoof helper module. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start or stop CDP quest] --> B[Execute cleanup on every Discord target]
    B --> C[Verify bridges, hooks, patches, and fake game]
    C -->|Clean| D[Continue quest control flow]
    C -->|Dirty or target error| E{Attempts remaining?}
    E -->|Yes| B
    E -->|No| F[Return cleanup error]
    F --> G[Wrapper logs error]
    G --> D
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22masterain98%2Fdiscord-quest-helper%22%20on%20the%20existing%20branch%20%22feat%2Fcdp-status-fidelity%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcdp-status-fidelity%22.%0A%0AGreploop%20masterain98%2Fdiscord-quest-helper%20PR%20%23160%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=masterain98%2Fdiscord-quest-helper&pr=160&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["fix(cdp): address PR review findings and..."](https://github.com/masterain98/discord-quest-helper/commit/0fa55b14686bb50698b190508b56e04d6631433b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52866067)</sub>

<!-- /greptile_comment -->