### PR TITLE
feat(cdp): spoof running games through Discord's native observer

### DIFF
--- a/crates/discord-cdp-launch-core/src/cdp.rs
+++ b/crates/discord-cdp-launch-core/src/cdp.rs
@@ -62,12 +62,17 @@ pub fn is_discord_target(target: &CdpTarget) -> bool {
 /// Overlay and popout windows are Discord pages, but they do not load
 /// `webpackChunkdiscord_app` or `DiscordNative`. Live Discord CDP lists
 /// `Discord Overlay` (`https://discord.com/popout`) before the main renderer.
-fn is_discord_auxiliary_window(target: &CdpTarget) -> bool {
-    if target.title.eq_ignore_ascii_case("discord overlay") {
+pub fn is_discord_auxiliary_window(target: &CdpTarget) -> bool {
+    is_discord_auxiliary_page(&target.title, &target.url)
+}
+
+/// Title/URL form used when CDP execution results no longer carry a full target.
+pub fn is_discord_auxiliary_page(title: &str, url: &str) -> bool {
+    if title.eq_ignore_ascii_case("discord overlay") {
         return true;
     }
 
-    let path = discord_target_path(&target.url);
+    let path = discord_target_path(url);
     path == "popout"
         || path.starts_with("popout/")
         || path == "overlay"
@@ -303,6 +308,15 @@ mod tests {
     fn overlay_is_still_a_discord_page_target() {
         let overlay = target("overlay", "Discord Overlay", "https://discord.com/popout");
         assert!(is_discord_target(&overlay));
+        assert!(is_discord_auxiliary_window(&overlay));
+        assert!(is_discord_auxiliary_page(
+            "Discord Overlay",
+            "https://discord.com/popout"
+        ));
+        assert!(!is_discord_auxiliary_page(
+            "Friends",
+            "https://discord.com/channels/@me"
+        ));
     }
 }
 

--- a/crates/discord-cdp-launch-core/src/cdp.rs
+++ b/crates/discord-cdp-launch-core/src/cdp.rs
@@ -245,6 +245,36 @@ fn parse_http_response(response: &[u8]) -> CdpProbeStatus {
     }
 }
 
+fn target_from_value(value: &Value) -> Option<CdpTarget> {
+    let object = value.as_object()?;
+    Some(CdpTarget {
+        id: object
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        target_type: object
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        title: object
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        url: object
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        web_socket_debugger_url: object
+            .get("webSocketDebuggerUrl")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -318,34 +348,4 @@ mod tests {
             "https://discord.com/channels/@me"
         ));
     }
-}
-
-fn target_from_value(value: &Value) -> Option<CdpTarget> {
-    let object = value.as_object()?;
-    Some(CdpTarget {
-        id: object
-            .get("id")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string(),
-        target_type: object
-            .get("type")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string(),
-        title: object
-            .get("title")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string(),
-        url: object
-            .get("url")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string(),
-        web_socket_debugger_url: object
-            .get("webSocketDebuggerUrl")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-    })
 }

--- a/crates/discord-cdp-launch-core/src/lib.rs
+++ b/crates/discord-cdp-launch-core/src/lib.rs
@@ -6,7 +6,10 @@ mod model;
 mod platform;
 mod processes;
 
-pub use cdp::{is_discord_target, pick_discord_target, probe_cdp, CdpProbe, StdCdpProbe};
+pub use cdp::{
+    is_discord_auxiliary_page, is_discord_auxiliary_window, is_discord_target, pick_discord_target,
+    probe_cdp, CdpProbe, StdCdpProbe,
+};
 pub use channel::{parse_discord_channel, DiscordChannel};
 pub use error::LaunchError;
 pub use launcher::{

--- a/src-tauri/src/cdp_client.rs
+++ b/src-tauri/src/cdp_client.rs
@@ -58,6 +58,14 @@ pub struct CdpRunningGamesSnapshot {
     pub native_module_methods: Vec<String>,
     pub games: Vec<serde_json::Value>,
     pub visible_games: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub visible_game: Option<serde_json::Value>,
+    #[serde(default)]
+    pub analytics_game: Option<serde_json::Value>,
+    #[serde(default)]
+    pub debug_game: Option<serde_json::Value>,
+    #[serde(default)]
+    pub store_views_diff: Option<serde_json::Value>,
     pub native_diagnostics: Vec<serde_json::Value>,
     pub errors: Vec<String>,
 }
@@ -399,6 +407,22 @@ const JS_READ_RUNNING_GAMES: &str = r###"
             } catch (error) {
               result.errors.push("getVisibleRunningGames: " + String(error));
             }
+            try { result.visible_game = serialize(store.getVisibleGame ? store.getVisibleGame() : null); }
+            catch (error) { result.errors.push("getVisibleGame: " + String(error)); }
+            try { result.analytics_game = serialize(store.getCurrentGameForAnalytics ? store.getCurrentGameForAnalytics() : null); }
+            catch (error) { result.errors.push("getCurrentGameForAnalytics: " + String(error)); }
+            try { result.debug_game = serialize(store.getDebugRunningGame ? store.getDebugRunningGame() : null); }
+            catch (error) { result.errors.push("getDebugRunningGame: " + String(error)); }
+            const runningIds = (Array.isArray(result.games) ? result.games : []).map(game => game && game.id);
+            result.store_views_diff = {
+              runningCount: runningIds.length,
+              runningIds,
+              visibleId: result.visible_game && result.visible_game.id ? result.visible_game.id : null,
+              analyticsId: result.analytics_game && result.analytics_game.id ? result.analytics_game.id : null,
+              debugId: result.debug_game && result.debug_game.id ? result.debug_game.id : null,
+              visibleInRunning: !!(result.visible_game && result.visible_game.id && runningIds.some(id => String(id) === String(result.visible_game.id))),
+              analyticsInRunning: !!(result.analytics_game && result.analytics_game.id && runningIds.some(id => String(id) === String(result.analytics_game.id)))
+            };
             found = true;
             break;
           }
@@ -1756,6 +1780,9 @@ mod tests {
             "must capture webpack require from push() return value, not the runtime callback argument"
         );
         assert!(JS_READ_RUNNING_GAMES.contains("Array.isArray(games)"));
+        assert!(JS_READ_RUNNING_GAMES.contains("store_views_diff"));
+        assert!(JS_READ_RUNNING_GAMES.contains("getCurrentGameForAnalytics"));
+        assert!(JS_READ_RUNNING_GAMES.contains("getDebugRunningGame"));
         assert!(!JS_READ_RUNNING_GAMES
             .contains("runtimeRequire => { webpackRequire = runtimeRequire; }"));
         assert!(!JS_READ_RUNNING_GAMES
@@ -1859,6 +1886,19 @@ mod tests {
         ];
         let fallback_none = select_discord_targets(&fallback_missing_ws);
         assert_eq!(fallback_none.len(), 0);
+    }
+
+    #[test]
+    fn test_select_discord_targets_keeps_overlay_for_cleanup() {
+        let targets = vec![
+            mk_target("page", "Discord Overlay", "https://discord.com/popout"),
+            mk_target("page", "Friends", "https://discord.com/channels/@me"),
+        ];
+        let selected = select_discord_targets(&targets);
+        assert_eq!(selected.len(), 2);
+        assert!(selected.iter().any(|t| t.title == "Discord Overlay"));
+        assert!(selected.iter().any(|t| t.title == "Friends"));
+        assert!(pick_discord_target(&targets).is_some_and(|t| t.title == "Friends"));
     }
 
     fn request_will_be_sent(request_id: &str, url: &str, authorization: Option<&str>) -> String {

--- a/src-tauri/src/cdp_game_spoof.rs
+++ b/src-tauri/src/cdp_game_spoof.rs
@@ -109,6 +109,9 @@ pub struct CleanupVerify {
     pub fake_game_present: bool,
     pub has_dispatch_hook: bool,
     pub broad_patch_count: u64,
+    pub observer_hook: bool,
+    pub fake_in_running_games: bool,
+    pub debug_game_present: bool,
 }
 
 /// Official Discord desktop game-quest heartbeat cadence, from
@@ -140,6 +143,7 @@ pub const RUNNING_GAME_SCHEMA_KEYS: &[&str] = &[
     "processName",
     "sandboxed",
     "sku",
+    "start",
     "windowHandle",
 ];
 
@@ -259,11 +263,13 @@ fn merge_running_games<'a>(
     real: &[RunningGameIdentity<'a>],
     fake: RunningGameIdentity<'a>,
 ) -> Vec<RunningGameIdentity<'a>> {
-    let mut merged: Vec<RunningGameIdentity<'a>> = real
+    if real
         .iter()
-        .copied()
-        .filter(|game| game.id != fake.id && game.pid != fake.pid)
-        .collect();
+        .any(|game| game.id == fake.id || game.pid == fake.pid)
+    {
+        return real.to_vec();
+    }
+    let mut merged = real.to_vec();
     merged.push(fake);
     merged
 }
@@ -308,6 +314,9 @@ pub fn cleanup_verify_is_clean(verify: &CleanupVerify) -> bool {
         && !verify.fake_game_present
         && !verify.has_dispatch_hook
         && verify.broad_patch_count == 0
+        && !verify.observer_hook
+        && !verify.fake_in_running_games
+        && !verify.debug_game_present
 }
 
 pub fn cleanup_verify_from_json(parsed: &serde_json::Value) -> Option<CleanupVerify> {
@@ -335,6 +344,18 @@ pub fn cleanup_verify_from_json(parsed: &serde_json::Value) -> Option<CleanupVer
             .get("broadPatchCount")
             .and_then(|value| value.as_u64())
             .unwrap_or(0),
+        observer_hook: parsed
+            .get("observerHook")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        fake_in_running_games: parsed
+            .get("fakeInRunningGames")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        debug_game_present: parsed
+            .get("debugGamePresent")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
     })
 }
 
@@ -460,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn merge_keeps_real_games_and_appends_fake() {
+    fn merge_keeps_native_entry_with_the_same_application_id() {
         let real = [
             RunningGameIdentity {
                 id: "other",
@@ -479,6 +500,22 @@ mod tests {
         assert_eq!(merged.len(), 2);
         assert_eq!(merged[0].id, "other");
         assert_eq!(merged[1].id, "stale");
+        assert_eq!(merged[1].pid, 22);
+    }
+
+    #[test]
+    fn merge_appends_fake_only_when_id_is_absent() {
+        let real = [RunningGameIdentity {
+            id: "other",
+            pid: 11,
+        }];
+        let fake = RunningGameIdentity {
+            id: "fresh",
+            pid: 99,
+        };
+        let merged = merge_running_games(&real, fake);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[1].id, "fresh");
         assert_eq!(merged[1].pid, 99);
     }
 
@@ -517,6 +554,7 @@ mod tests {
             "sku",
             "gameMetadata",
             "executableFingerprint",
+            "start",
         ] {
             assert!(RUNNING_GAME_SCHEMA_KEYS.contains(&key));
         }
@@ -546,10 +584,21 @@ mod tests {
             fake_game_present: false,
             has_dispatch_hook: false,
             broad_patch_count: 0,
+            observer_hook: false,
+            fake_in_running_games: false,
+            debug_game_present: false,
         };
         assert!(cleanup_verify_is_clean(&clean));
         assert!(!cleanup_verify_is_clean(&CleanupVerify {
             has_dispatch_hook: true,
+            ..clean.clone()
+        }));
+        assert!(!cleanup_verify_is_clean(&CleanupVerify {
+            observer_hook: true,
+            ..clean.clone()
+        }));
+        assert!(!cleanup_verify_is_clean(&CleanupVerify {
+            debug_game_present: true,
             ..clean.clone()
         }));
         assert!(cleanup_verify_from_json(&serde_json::json!({
@@ -558,7 +607,10 @@ mod tests {
             "spoofActive": false,
             "fakeGamePresent": false,
             "hasDispatchHook": false,
-            "broadPatchCount": 0
+            "broadPatchCount": 0,
+            "observerHook": false,
+            "fakeInRunningGames": false,
+            "debugGamePresent": false
         }))
         .is_some_and(|verify| cleanup_verify_is_clean(&verify)));
     }

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -29,6 +29,7 @@ const QUEST_WARMUP_DWELL_MS: u64 = 1500;
 const QUEST_WARMUP_RESTORE_SETTLE_MS: u64 = 800;
 const CDP_CLEANUP_ATTEMPTS: u32 = 5;
 const CDP_CLEANUP_CANCEL_ATTEMPTS: u32 = 1;
+const CDP_CLEANUP_VERIFY_TIMEOUT_SECS: u64 = 10;
 
 /// JavaScript: Initialize quest-related Discord webpack modules and store them in window.__dqh_cdp.
 ///
@@ -563,12 +564,14 @@ fn js_spoof_play_game_for(
             return patchedGetRunningGames().find(x => x && String(x.name || "").toLowerCase() === needle) || null;
         }}
         function patchedGetVisibleGame() {{
+            if (dqh._spoofActive && dqh._fakeGame && !dqh._fakeGame.hidden) return dqh._fakeGame;
             let visible = null;
             try {{ visible = dqh._origGetVisibleGame && dqh._origGetVisibleGame.call(dqh.RunningGameStore); }} catch(e) {{}}
             if (visible) return visible;
             return patchedGetRunningGames().find(g => g && !g.hidden) || dqh._fakeGame || null;
         }}
         function patchedGetCurrentGameForAnalytics() {{
+            if (dqh._spoofActive && dqh._fakeGame) return dqh._fakeGame;
             let current = null;
             try {{ current = dqh._origGetCurrentGameForAnalytics && dqh._origGetCurrentGameForAnalytics.call(dqh.RunningGameStore); }} catch(e) {{}}
             if (current) return current;
@@ -663,8 +666,8 @@ fn js_spoof_play_game_for(
         }}
 
         const mergedGames = mergeFake(realGames, fakeGame);
-        dqh.FluxDispatcher.dispatch({{ type: "RUNNING_GAMES_CHANGE", removed: [], added: [fakeGame], games: mergedGames }});
         subscribeHeartbeats();
+        dqh.FluxDispatcher.dispatch({{ type: "RUNNING_GAMES_CHANGE", removed: [], added: [fakeGame], games: mergedGames }});
 
         return JSON.stringify({{ success: true, wrappedObserver, pid: fakeGame.pid || null, patchCount: patchCount, exeName: exeName, allExeNames: allExeNames, appDataName: appDataDebug, realGamesCount: realGames.length, mergedCount: mergedGames.length, hostOs: hostOs, selectedOs: selectedOs, usedHint: !!hint }});
     }} catch (e) {{
@@ -1035,19 +1038,7 @@ const JS_CLEANUP_SPOOF: &str = r#"
         }
         async function cleanupOne(dqh, name) {
             dqh._spoofActive = false;
-
-            if (dqh._origSetObservedGamesCallback && dqh.NativeUtils) {
-                dqh.NativeUtils.setObservedGamesCallback = dqh._origSetObservedGamesCallback;
-                delete dqh._origSetObservedGamesCallback;
-                try {
-                    const games = detectableGamesPayload(dqh);
-                    if (games.length > 0 && dqh.FluxDispatcher) {
-                        const pending = dqh.FluxDispatcher.dispatch({ type: "GAMES_DATABASE_UPDATE", games });
-                        if (pending && typeof pending.then === "function") await pending.catch(() => {});
-                    }
-                } catch(e) {}
-                await new Promise(resolve => setTimeout(resolve, 3000));
-            }
+            let awaitedObserverRefresh = false;
 
             if (dqh._origDispatch && dqh.FluxDispatcher) {
                 dqh.FluxDispatcher.dispatch = dqh._origDispatch;
@@ -1094,6 +1085,19 @@ const JS_CLEANUP_SPOOF: &str = r#"
                 }
             }
 
+            if (dqh._origSetObservedGamesCallback && dqh.NativeUtils) {
+                dqh.NativeUtils.setObservedGamesCallback = dqh._origSetObservedGamesCallback;
+                delete dqh._origSetObservedGamesCallback;
+                try {
+                    const games = detectableGamesPayload(dqh);
+                    if (games.length > 0 && dqh.FluxDispatcher) {
+                        const pending = dqh.FluxDispatcher.dispatch({ type: "GAMES_DATABASE_UPDATE", games });
+                        if (pending && typeof pending.then === "function") await pending.catch(() => {});
+                    }
+                } catch(e) {}
+                awaitedObserverRefresh = true;
+            }
+
             if (dqh.FluxDispatcher && dqh._heartbeatFn) {
                 dqh.FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", dqh._heartbeatFn);
             }
@@ -1110,13 +1114,13 @@ const JS_CLEANUP_SPOOF: &str = r#"
                 remaining = [];
             }
             if (!Array.isArray(remaining)) remaining = [];
-            if (dqh._fakeGame && Array.isArray(remaining)) {
-                for (let i = remaining.length - 1; i >= 0; i--) {
-                    const game = remaining[i];
-                    if (game && (String(game.id) === String(dqh._fakeGame.id) || (dqh._fakeGame.pid != null && game.pid === dqh._fakeGame.pid))) {
-                        remaining.splice(i, 1);
-                    }
-                }
+            if (dqh._fakeGame) {
+                remaining = remaining.filter(game =>
+                    !game || (
+                        String(game.id) !== String(dqh._fakeGame.id)
+                        && (dqh._fakeGame.pid == null || game.pid !== dqh._fakeGame.pid)
+                    )
+                );
             }
             if (dqh.FluxDispatcher && dqh._fakeGame) {
                 dqh.FluxDispatcher.dispatch({ type: "RUNNING_GAMES_CHANGE", removed: [dqh._fakeGame], added: [], games: remaining });
@@ -1127,14 +1131,19 @@ const JS_CLEANUP_SPOOF: &str = r#"
             } catch (e) {
                 try { window[name] = undefined; } catch (e2) {}
             }
+            return awaitedObserverRefresh;
         }
 
         let cleaned = 0;
+        let needsObserverSettle = false;
         for (const name of names) {
             const dqh = window[name];
             if (!isDqhBridge(dqh)) continue;
-            await cleanupOne(dqh, name);
+            needsObserverSettle = (await cleanupOne(dqh, name)) || needsObserverSettle;
             cleaned++;
+        }
+        if (needsObserverSettle) {
+            await new Promise(resolve => setTimeout(resolve, 3000));
         }
         return JSON.stringify({ success: true, cleaned });
     } catch (e) {
@@ -1187,24 +1196,35 @@ const JS_VERIFY_CLEANUP_STATE: &str = r#"
             let store = null;
             let nativeUtils = null;
             for (const mod of Object.values(webpackRequire.c || {})) {
-                const exp = mod && mod.exports;
-                if (!exp) continue;
-                for (const key of Object.keys(exp)) {
-                    const val = exp[key];
-                    if (!store && typeof val?.getRunningGames === "function") {
+                try {
+                    const exp = mod && mod.exports;
+                    if (!exp) continue;
+                    for (const key of Object.keys(exp)) {
                         try {
-                            const games = val.getRunningGames();
-                            if (Array.isArray(games)) store = val;
+                            const val = exp[key];
+                            if (!val) continue;
+                            if (!store && typeof val.getRunningGames === "function") {
+                                try {
+                                    const games = val.getRunningGames();
+                                    if (Array.isArray(games)) store = val;
+                                } catch(e) {}
+                            }
+                            if (!nativeUtils && typeof val.getDiscordUtils === "function" && typeof val.setObservedGamesCallback === "function" && typeof val.setGameCandidateOverrides === "function") {
+                                nativeUtils = val;
+                            }
                         } catch(e) {}
                     }
-                    if (!nativeUtils && typeof val?.getDiscordUtils === "function" && typeof val?.setObservedGamesCallback === "function" && typeof val?.setGameCandidateOverrides === "function") {
-                        nativeUtils = val;
-                    }
-                }
+                } catch(e) {}
+                if (store && nativeUtils) break;
             }
             if (store) {
                 try {
-                    debugGamePresent = !!store.getDebugRunningGame?.();
+                    const debugGame = store.getDebugRunningGame?.();
+                    debugGamePresent = !!(
+                        fakeApplicationId
+                        && debugGame
+                        && String(debugGame.id) === String(fakeApplicationId)
+                    );
                     const games = store.getRunningGames() || [];
                     if (fakeApplicationId) {
                         fakeInRunningGames = games.some(g => g && String(g.id) === String(fakeApplicationId));
@@ -1949,7 +1969,14 @@ async fn cdp_cleanup_with_attempts(port: u16, max_attempts: u32) -> Result<()> {
             }
         }
 
-        match cdp_client::execute_js_via_all_discord_targets(port, &verify_js, false, 5).await {
+        match cdp_client::execute_js_via_all_discord_targets(
+            port,
+            &verify_js,
+            false,
+            CDP_CLEANUP_VERIFY_TIMEOUT_SECS,
+        )
+        .await
+        {
             Ok(results) => {
                 let mut verify_checked = 0usize;
                 let mut verify_dirty = 0usize;
@@ -4025,9 +4052,23 @@ mod tests {
         assert!(!js.contains("notifyGameLaunched"));
         assert!(!js.contains("nativeAlreadyPresent"));
         assert!(!js.contains("RUNNING_GAME_SET_DEBUG_GAME"));
+        assert!(js.contains(
+            "if (dqh._spoofActive && dqh._fakeGame && !dqh._fakeGame.hidden) return dqh._fakeGame"
+        ));
+        assert!(js.contains("if (dqh._spoofActive && dqh._fakeGame) return dqh._fakeGame"));
         assert!(js.contains("if (visible) return visible"));
         assert!(js.contains("const already = Array.isArray(event.games)"));
         assert!(js.contains("wrappedCb"));
+        let subscribe_call = js
+            .rfind("subscribeHeartbeats();")
+            .expect("heartbeat subscription should be invoked");
+        let running_games_dispatch = js
+            .find(r#"type: "RUNNING_GAMES_CHANGE", removed: [], added: [fakeGame]"#)
+            .expect("spoof should dispatch RUNNING_GAMES_CHANGE");
+        assert!(
+            subscribe_call < running_games_dispatch,
+            "heartbeat listeners must be attached before RUNNING_GAMES_CHANGE"
+        );
     }
 
     #[test]
@@ -4066,6 +4107,9 @@ mod tests {
         ));
         assert!(JS_VERIFY_CLEANUP_STATE.contains("debugGamePresent"));
         assert!(JS_VERIFY_CLEANUP_STATE.contains("getDebugRunningGame"));
+        assert!(
+            JS_VERIFY_CLEANUP_STATE.contains("String(debugGame.id) === String(fakeApplicationId)")
+        );
     }
 
     #[test]
@@ -4139,6 +4183,9 @@ mod tests {
     fn cleanup_js_restores_real_games_instead_of_empty_list() {
         assert!(JS_CLEANUP_SPOOF.contains("games: remaining"));
         assert!(!JS_CLEANUP_SPOOF.contains("games: []"));
+        assert!(JS_CLEANUP_SPOOF.contains("remaining = remaining.filter"));
+        assert!(!JS_CLEANUP_SPOOF.contains("remaining.splice"));
+        assert!(JS_CLEANUP_SPOOF.contains("needsObserverSettle"));
         assert!(JS_CLEANUP_SPOOF.contains(r#"__" + "dqh_cdp""#));
         assert!(JS_CLEANUP_SPOOF.contains("^__n[0-9a-f]{10}$"));
         assert!(JS_CLEANUP_SPOOF.contains("_origSetObservedGamesCallback"));
@@ -4147,6 +4194,8 @@ mod tests {
         assert!(JS_VERIFY_CLEANUP_STATE.contains("observerHook"));
         assert!(JS_VERIFY_CLEANUP_STATE.contains("fakeInRunningGames"));
         assert!(JS_VERIFY_CLEANUP_STATE.contains("debugGamePresent"));
+        assert!(JS_VERIFY_CLEANUP_STATE
+            .contains("try {\n                            const val = exp[key];"));
         assert!(JS_INIT_QUEST_MODULES.contains("NativeUtils"));
         assert!(JS_INIT_QUEST_MODULES.contains("DetectableGameStore"));
         assert!(JS_INIT_QUEST_MODULES.contains("const DQH_INIT_VERSION = 7"));
@@ -4246,7 +4295,7 @@ mod tests {
             port,
             &with_bridge(JS_VERIFY_CLEANUP_STATE),
             false,
-            5,
+            CDP_CLEANUP_VERIFY_TIMEOUT_SECS,
         )
         .await;
         let verify_raw = verify_raw.expect("cleanup verify should execute");

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -20,6 +20,7 @@ use crate::cdp_game_spoof::{
     SimulatedProcessHint,
 };
 use crate::models::PlayActivityHeartbeatStatus;
+use discord_cdp_launch_core::is_discord_auxiliary_page;
 
 const QUEST_HOME_URL: &str = "https://discord.com/quest-home";
 const QUEST_HOME_DETOUR_URL: &str = "https://discord.com/store";
@@ -42,7 +43,7 @@ const CDP_CLEANUP_CANCEL_ATTEMPTS: u32 = 1;
 const JS_INIT_QUEST_MODULES: &str = r#"
 (async () => {
     try {
-        const DQH_INIT_VERSION = 6;
+        const DQH_INIT_VERSION = 7;
         if (window.__dqh_cdp && window.__dqh_cdp.initialized && window.__dqh_cdp._initVersion === DQH_INIT_VERSION) {
             return JSON.stringify({ success: true, cached: true });
         }
@@ -56,7 +57,9 @@ const JS_INIT_QUEST_MODULES: &str = r#"
             QuestsStore: null,
             FluxDispatcher: null,
             ApplicationStreamingStore: null,
-            api: null
+            api: null,
+            NativeUtils: null,
+            DetectableGameStore: null
         };
 
         // Phase 1: Scan all webpack modules for stores (prototype-based detection)
@@ -99,6 +102,19 @@ const JS_INIT_QUEST_MODULES: &str = r#"
                         // QuestsStore: __proto__ has getQuest
                         if (!modules.QuestsStore && val?.__proto__?.getQuest) {
                             modules.QuestsStore = val;
+                        }
+
+                        // Native utils wrapper used by RunningGameStore to register
+                        // setObservedGamesCallback. Unique vs i18n decoys because it
+                        // also exposes getDiscordUtils + setGameCandidateOverrides.
+                        if (!modules.NativeUtils && typeof val?.getDiscordUtils === "function" && typeof val?.setObservedGamesCallback === "function" && typeof val?.setGameCandidateOverrides === "function") {
+                            modules.NativeUtils = val;
+                        }
+
+                        // DetectableGameStore: getGameByExecutable distinguishes the
+                        // real module from i18n getDetectableGame decoys.
+                        if (!modules.DetectableGameStore && typeof val?.getDetectableGame === "function" && typeof val?.getGameByExecutable === "function" && typeof val?.findGame === "function") {
+                            modules.DetectableGameStore = val;
                         }
 
                         // Collect API candidates: any module with get + post functions
@@ -145,7 +161,7 @@ const JS_INIT_QUEST_MODULES: &str = r#"
 
         let missing = [];
         for (const [name, mod] of Object.entries(modules)) {
-            if (!mod) missing.push(name);
+            if (!mod && name !== "NativeUtils" && name !== "DetectableGameStore") missing.push(name);
         }
 
         if (missing.length > 0) {
@@ -161,6 +177,9 @@ const JS_INIT_QUEST_MODULES: &str = r#"
             _origGetRunningGames: modules.RunningGameStore.getRunningGames,
             _origGetGameForPID: modules.RunningGameStore.getGameForPID || null,
             _origGetVisibleRunningGames: modules.RunningGameStore.getVisibleRunningGames || null,
+            _origGetVisibleGame: modules.RunningGameStore.getVisibleGame || null,
+            _origGetCurrentGameForAnalytics: modules.RunningGameStore.getCurrentGameForAnalytics || null,
+            _origGetGameForName: modules.RunningGameStore.getGameForName || null,
             _origGetStreamerActiveStreamMetadata: modules.ApplicationStreamingStore.getStreamerActiveStreamMetadata
             },
             writable: true,
@@ -284,8 +303,9 @@ fn js_play_activity_status(quest_id: &str) -> String {
 
 /// Generate JS to spoof a running game in RunningGameStore.
 ///
-/// Merges the spoofed game into the real scanner list, then dispatches
-/// `RUNNING_GAMES_CHANGE` so Discord's heartbeat system picks it up.
+/// Always injects via the native observer callback (append, never prepend),
+/// then dispatches `RUNNING_GAMES_CHANGE` so Discord's own heartbeat system
+/// picks the synthetic game up. Does not wait for or reuse a native detection.
 fn js_spoof_play_game(app_id: &str, app_name: &str) -> String {
     js_spoof_play_game_for(
         app_id,
@@ -348,10 +368,39 @@ fn js_spoof_play_game_for(
                 .split("{{app_slug}}").join(appSlug(app))
                 .split("{{exe}}").join(exe);
         }}
+        function sameGame(game, fake) {{
+            if (!game || !fake) return false;
+            if (String(game.id) === String(fake.id)) return true;
+            return fake.pid != null && game.pid === fake.pid;
+        }}
         function mergeFake(games, fake) {{
-            const list = Array.isArray(games) ? games.filter(g => g && g.id !== fake.id && g.pid !== fake.pid) : [];
+            const list = Array.isArray(games) ? games.slice() : [];
+            if (!fake) return list;
+            if (list.some(g => sameGame(g, fake))) return list;
             list.push(fake);
             return list;
+        }}
+        function detectableGamesPayload() {{
+            const store = dqh.DetectableGameStore;
+            if (!store) return [];
+            let raw = store.games;
+            if (typeof raw === "function") {{
+                try {{ raw = store.games(); }} catch(e) {{ return []; }}
+            }}
+            if (raw && typeof raw.values === "function") return Array.from(raw.values());
+            if (Array.isArray(raw)) return raw;
+            if (raw && typeof raw === "object") return Object.values(raw);
+            return [];
+        }}
+        function reregisterObserver() {{
+            try {{
+                const games = detectableGamesPayload();
+                dqh._detectableGamesPayload = games;
+                if (games.length > 0 && dqh.FluxDispatcher) {{
+                    const pending = dqh.FluxDispatcher.dispatch({{ type: "GAMES_DATABASE_UPDATE", games }});
+                    if (pending && typeof pending.then === "function") pending.catch(() => {{}});
+                }}
+            }} catch(e) {{}}
         }}
 
         const applicationId = {safe_app_id};
@@ -390,30 +439,59 @@ fn js_spoof_play_game_for(
         }});
         const builtCmd = render(pathTemplates.cmdLine, sanitizeApp(applicationName), exeName);
         const builtPath = render(pathTemplates.exePath, sanitizeApp(applicationName), exeName);
-        const pid = hint && hint.pid ? hint.pid : Math.floor(Math.random() * 30000) + 1000;
+
+        let seenMatch = null;
+        try {{
+            const seen = typeof dqh.RunningGameStore.getGamesSeen === "function"
+                ? dqh.RunningGameStore.getGamesSeen(false)
+                : [];
+            if (Array.isArray(seen)) {{
+                seenMatch = seen.find(g => g && String(g.id) === String(applicationId)) || null;
+            }}
+        }} catch(e) {{}}
+
         const fakeGame = {{
             id: applicationId,
-            nativeProcessObserverId: pid,
             name: applicationName,
             origGameName: applicationName,
             processName: applicationName,
             hidden: false,
             elevated: false,
             sandboxed: false,
-            lastFocused: Date.now(),
-            exePath: hint && hint.exePath ? hint.exePath : builtPath,
+            lastFocused: 0,
+            start: Date.now(),
+            exePath: (hint && hint.exePath) || (seenMatch && seenMatch.exePath) || builtPath,
             exeName: exeName,
-            cmdLine: hint && hint.cmdLine ? hint.cmdLine : builtCmd,
-            pid: pid,
-            pidPath: [pid],
+            cmdLine: (hint && hint.cmdLine) || (seenMatch && seenMatch.cmdLine) || builtCmd,
             windowHandle: null,
             fullscreenType: null,
             isLauncher: false,
-            distributor: undefined,
-            sku: undefined,
+            distributor: seenMatch && seenMatch.distributor !== undefined ? seenMatch.distributor : undefined,
+            sku: seenMatch && seenMatch.sku !== undefined ? seenMatch.sku : undefined,
             gameMetadata: undefined,
             executableFingerprint: undefined
         }};
+        if (seenMatch && seenMatch.nativeProcessObserverId != null) {{
+            fakeGame.nativeProcessObserverId = seenMatch.nativeProcessObserverId;
+        }}
+        if (hint && hint.pid) {{
+            fakeGame.pid = hint.pid;
+            fakeGame.pidPath = [hint.pid];
+            try {{
+                const utils = dqh.NativeUtils && dqh.NativeUtils.getDiscordUtils && dqh.NativeUtils.getDiscordUtils();
+                if (utils && typeof utils.getWindowHandleFromPid === "function") {{
+                    const handle = utils.getWindowHandleFromPid(hint.pid);
+                    if (handle != null && handle !== "0") fakeGame.windowHandle = String(handle);
+                }}
+                if (utils && typeof utils.getWindowFullscreenTypeByPid === "function") {{
+                    const fullscreen = utils.getWindowFullscreenTypeByPid(hint.pid);
+                    if (fullscreen != null) fakeGame.fullscreenType = fullscreen;
+                }} else if (dqh.NativeUtils && typeof dqh.NativeUtils.GetWindowFullscreenTypeByPid === "function") {{
+                    const fullscreen = dqh.NativeUtils.GetWindowFullscreenTypeByPid(hint.pid);
+                    if (fullscreen != null) fakeGame.fullscreenType = fullscreen;
+                }}
+            }} catch(e) {{}}
+        }}
 
         let realGames = [];
         try {{ realGames = dqh._origGetRunningGames.call(dqh.RunningGameStore); }} catch(e) {{
@@ -421,8 +499,54 @@ fn js_spoof_play_game_for(
         }}
         if (!Array.isArray(realGames)) realGames = [];
 
-        dqh._fakeGame = fakeGame;
         dqh._spoofActive = true;
+        dqh._fakeGame = fakeGame;
+        dqh._fakeApplicationId = applicationId;
+
+        function subscribeHeartbeats() {{
+            dqh._lastProgress = 0;
+            dqh._completed = false;
+            dqh._heartbeatCount = 0;
+            dqh._lastHeartbeatRaw = null;
+            if (dqh._heartbeatFn && dqh.FluxDispatcher) {{
+                try {{ dqh.FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", dqh._heartbeatFn); }} catch(e) {{}}
+            }}
+            let heartbeatFn = data => {{
+                try {{
+                    dqh._heartbeatCount++;
+                    try {{ dqh._lastHeartbeatRaw = JSON.stringify(data).substring(0, 500); }} catch(e2) {{}}
+                    let progress = 0;
+                    if (data && data.userStatus) {{
+                        if (data.userStatus.progress) {{
+                            const vals = Object.values(data.userStatus.progress);
+                            if (vals.length > 0 && vals[0].value !== undefined) {{
+                                progress = Math.floor(vals[0].value);
+                            }}
+                        }} else if (data.userStatus.streamProgressSeconds !== undefined) {{
+                            progress = data.userStatus.streamProgressSeconds;
+                        }}
+                        dqh._completed = !!data.userStatus.completedAt;
+                    }}
+                    dqh._lastProgress = progress;
+                }} catch(e) {{}}
+            }};
+            dqh._heartbeatFn = heartbeatFn;
+            dqh.FluxDispatcher.subscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", heartbeatFn);
+
+            dqh._lastHeartbeatFailure = null;
+            if (dqh._heartbeatFailFn && dqh.FluxDispatcher) {{
+                try {{ dqh.FluxDispatcher.unsubscribe("QUESTS_SEND_HEARTBEAT_FAILURE", dqh._heartbeatFailFn); }} catch(e) {{}}
+            }}
+            let heartbeatFailFn = data => {{
+                try {{
+                    dqh._lastHeartbeatFailure = JSON.stringify(data).substring(0, 500);
+                }} catch(e) {{
+                    dqh._lastHeartbeatFailure = "failed to serialize";
+                }}
+            }};
+            dqh._heartbeatFailFn = heartbeatFailFn;
+            dqh.FluxDispatcher.subscribe("QUESTS_SEND_HEARTBEAT_FAILURE", heartbeatFailFn);
+        }}
 
         function patchedGetRunningGames() {{
             let games = [];
@@ -433,6 +557,22 @@ fn js_spoof_play_game_for(
         }}
         function patchedGetGameForPID(p) {{
             return patchedGetRunningGames().find(x => x.pid === p);
+        }}
+        function patchedGetGameForName(name) {{
+            const needle = String(name || "").toLowerCase();
+            return patchedGetRunningGames().find(x => x && String(x.name || "").toLowerCase() === needle) || null;
+        }}
+        function patchedGetVisibleGame() {{
+            let visible = null;
+            try {{ visible = dqh._origGetVisibleGame && dqh._origGetVisibleGame.call(dqh.RunningGameStore); }} catch(e) {{}}
+            if (visible) return visible;
+            return patchedGetRunningGames().find(g => g && !g.hidden) || dqh._fakeGame || null;
+        }}
+        function patchedGetCurrentGameForAnalytics() {{
+            let current = null;
+            try {{ current = dqh._origGetCurrentGameForAnalytics && dqh._origGetCurrentGameForAnalytics.call(dqh.RunningGameStore); }} catch(e) {{}}
+            if (current) return current;
+            return patchedGetRunningGames()[0] || dqh._fakeGame || null;
         }}
         function patchVisibleAccessor(store, origVisible) {{
             if (typeof origVisible !== "function") return;
@@ -446,6 +586,9 @@ fn js_spoof_play_game_for(
         }}
         dqh.RunningGameStore.getRunningGames = patchedGetRunningGames;
         dqh.RunningGameStore.getGameForPID = patchedGetGameForPID;
+        if (typeof dqh._origGetGameForName === "function") dqh.RunningGameStore.getGameForName = patchedGetGameForName;
+        if (typeof dqh._origGetVisibleGame === "function") dqh.RunningGameStore.getVisibleGame = patchedGetVisibleGame;
+        if (typeof dqh._origGetCurrentGameForAnalytics === "function") dqh.RunningGameStore.getCurrentGameForAnalytics = patchedGetCurrentGameForAnalytics;
         patchVisibleAccessor(dqh.RunningGameStore, dqh._origGetVisibleRunningGames);
 
         let patchCount = 1;
@@ -480,6 +623,21 @@ fn js_spoof_play_game_for(
         }} catch(e) {{}}
         dqh._broadPatched = broadPatched;
 
+        let wrappedObserver = false;
+        if (dqh.NativeUtils && typeof dqh.NativeUtils.setObservedGamesCallback === "function" && !dqh._origSetObservedGamesCallback) {{
+            const origObserved = dqh.NativeUtils.setObservedGamesCallback.bind(dqh.NativeUtils);
+            dqh._origSetObservedGamesCallback = origObserved;
+            dqh.NativeUtils.setObservedGamesCallback = function(config, flag, cb, userId) {{
+                const wrappedCb = function(games) {{
+                    if (!dqh._spoofActive || !dqh._fakeGame) return cb(games);
+                    return cb(mergeFake(games, dqh._fakeGame));
+                }};
+                return origObserved(config, flag, wrappedCb, userId);
+            }};
+            wrappedObserver = true;
+            reregisterObserver();
+        }}
+
         dqh._dispatchInterceptCount = 0;
         if (!dqh._origDispatch) {{
             const origDispatch = dqh.FluxDispatcher.dispatch.bind(dqh.FluxDispatcher);
@@ -487,13 +645,16 @@ fn js_spoof_play_game_for(
             dqh.FluxDispatcher.dispatch = function(event) {{
                 if (event && event.type === "RUNNING_GAMES_CHANGE" && dqh._fakeGame && dqh._spoofActive) {{
                     const before = Array.isArray(event.games) ? event.games.length : 0;
+                    const already = Array.isArray(event.games) && event.games.some(g => sameGame(g, dqh._fakeGame));
                     event.games = mergeFake(event.games, dqh._fakeGame);
-                    if (!event.added) event.added = [];
-                    if (!event.added.some(g => g && (g.id === dqh._fakeGame.id || g.pid === dqh._fakeGame.pid))) {{
-                        event.added.push(dqh._fakeGame);
+                    if (!already) {{
+                        if (!event.added) event.added = [];
+                        if (!event.added.some(g => sameGame(g, dqh._fakeGame))) {{
+                            event.added.push(dqh._fakeGame);
+                        }}
                     }}
                     if (event.removed) {{
-                        event.removed = event.removed.filter(g => g && g.id !== dqh._fakeGame.id && g.pid !== dqh._fakeGame.pid);
+                        event.removed = event.removed.filter(g => !sameGame(g, dqh._fakeGame));
                     }}
                     if (event.games.length !== before) dqh._dispatchInterceptCount++;
                 }}
@@ -503,45 +664,9 @@ fn js_spoof_play_game_for(
 
         const mergedGames = mergeFake(realGames, fakeGame);
         dqh.FluxDispatcher.dispatch({{ type: "RUNNING_GAMES_CHANGE", removed: [], added: [fakeGame], games: mergedGames }});
+        subscribeHeartbeats();
 
-        dqh._lastProgress = 0;
-        dqh._completed = false;
-        dqh._heartbeatCount = 0;
-        dqh._lastHeartbeatRaw = null;
-        let heartbeatFn = data => {{
-            try {{
-                dqh._heartbeatCount++;
-                try {{ dqh._lastHeartbeatRaw = JSON.stringify(data).substring(0, 500); }} catch(e2) {{}}
-                let progress = 0;
-                if (data && data.userStatus) {{
-                    if (data.userStatus.progress) {{
-                        const vals = Object.values(data.userStatus.progress);
-                        if (vals.length > 0 && vals[0].value !== undefined) {{
-                            progress = Math.floor(vals[0].value);
-                        }}
-                    }} else if (data.userStatus.streamProgressSeconds !== undefined) {{
-                        progress = data.userStatus.streamProgressSeconds;
-                    }}
-                    dqh._completed = !!data.userStatus.completedAt;
-                }}
-                dqh._lastProgress = progress;
-            }} catch(e) {{}}
-        }};
-        dqh._heartbeatFn = heartbeatFn;
-        dqh.FluxDispatcher.subscribe("QUESTS_SEND_HEARTBEAT_SUCCESS", heartbeatFn);
-
-        dqh._lastHeartbeatFailure = null;
-        let heartbeatFailFn = data => {{
-            try {{
-                dqh._lastHeartbeatFailure = JSON.stringify(data).substring(0, 500);
-            }} catch(e) {{
-                dqh._lastHeartbeatFailure = "failed to serialize";
-            }}
-        }};
-        dqh._heartbeatFailFn = heartbeatFailFn;
-        dqh.FluxDispatcher.subscribe("QUESTS_SEND_HEARTBEAT_FAILURE", heartbeatFailFn);
-
-        return JSON.stringify({{ success: true, pid: pid, patchCount: patchCount, exeName: exeName, allExeNames: allExeNames, appDataName: appDataDebug, realGamesCount: realGames.length, mergedCount: mergedGames.length, hostOs: hostOs, selectedOs: selectedOs, usedHint: !!hint }});
+        return JSON.stringify({{ success: true, wrappedObserver, pid: fakeGame.pid || null, patchCount: patchCount, exeName: exeName, allExeNames: allExeNames, appDataName: appDataDebug, realGamesCount: realGames.length, mergedCount: mergedGames.length, hostOs: hostOs, selectedOs: selectedOs, usedHint: !!hint }});
     }} catch (e) {{
         return JSON.stringify({{ success: false, error: String(e) }});
     }}
@@ -877,7 +1002,7 @@ fn js_query_progress(quest_id: &str) -> String {
 /// the historical `__dqh_cdp` name. The historical name is split so
 /// `with_bridge` cannot rewrite the lookup.
 const JS_CLEANUP_SPOOF: &str = r#"
-(() => {
+(async () => {
     try {
         const historical = "__" + "dqh_cdp";
         const names = Object.getOwnPropertyNames(window).filter(k =>
@@ -889,11 +1014,40 @@ const JS_CLEANUP_SPOOF: &str = r#"
                 || obj._spoofActive === true
                 || obj._fakeGame
                 || obj._origDispatch
+                || obj._origSetObservedGamesCallback
                 || (obj.initialized === true && obj.RunningGameStore)
             ));
         }
-        function cleanupOne(dqh, name) {
+        function detectableGamesPayload(dqh) {
+            if (Array.isArray(dqh._detectableGamesPayload) && dqh._detectableGamesPayload.length) {
+                return dqh._detectableGamesPayload;
+            }
+            const store = dqh.DetectableGameStore;
+            if (!store) return [];
+            let raw = store.games;
+            if (typeof raw === "function") {
+                try { raw = store.games(); } catch(e) { return []; }
+            }
+            if (raw && typeof raw.values === "function") return Array.from(raw.values());
+            if (Array.isArray(raw)) return raw;
+            if (raw && typeof raw === "object") return Object.values(raw);
+            return [];
+        }
+        async function cleanupOne(dqh, name) {
             dqh._spoofActive = false;
+
+            if (dqh._origSetObservedGamesCallback && dqh.NativeUtils) {
+                dqh.NativeUtils.setObservedGamesCallback = dqh._origSetObservedGamesCallback;
+                delete dqh._origSetObservedGamesCallback;
+                try {
+                    const games = detectableGamesPayload(dqh);
+                    if (games.length > 0 && dqh.FluxDispatcher) {
+                        const pending = dqh.FluxDispatcher.dispatch({ type: "GAMES_DATABASE_UPDATE", games });
+                        if (pending && typeof pending.then === "function") await pending.catch(() => {});
+                    }
+                } catch(e) {}
+                await new Promise(resolve => setTimeout(resolve, 3000));
+            }
 
             if (dqh._origDispatch && dqh.FluxDispatcher) {
                 dqh.FluxDispatcher.dispatch = dqh._origDispatch;
@@ -915,6 +1069,15 @@ const JS_CLEANUP_SPOOF: &str = r#"
                 }
                 if (typeof dqh._origGetVisibleRunningGames === "function") {
                     dqh.RunningGameStore.getVisibleRunningGames = dqh._origGetVisibleRunningGames;
+                }
+                if (typeof dqh._origGetVisibleGame === "function") {
+                    dqh.RunningGameStore.getVisibleGame = dqh._origGetVisibleGame;
+                }
+                if (typeof dqh._origGetCurrentGameForAnalytics === "function") {
+                    dqh.RunningGameStore.getCurrentGameForAnalytics = dqh._origGetCurrentGameForAnalytics;
+                }
+                if (typeof dqh._origGetGameForName === "function") {
+                    dqh.RunningGameStore.getGameForName = dqh._origGetGameForName;
                 }
             }
             if (dqh._origGetStreamerActiveStreamMetadata && dqh.ApplicationStreamingStore) {
@@ -947,8 +1110,13 @@ const JS_CLEANUP_SPOOF: &str = r#"
                 remaining = [];
             }
             if (!Array.isArray(remaining)) remaining = [];
-            if (dqh._fakeGame) {
-                remaining = remaining.filter(g => g && g.id !== dqh._fakeGame.id && g.pid !== dqh._fakeGame.pid);
+            if (dqh._fakeGame && Array.isArray(remaining)) {
+                for (let i = remaining.length - 1; i >= 0; i--) {
+                    const game = remaining[i];
+                    if (game && (String(game.id) === String(dqh._fakeGame.id) || (dqh._fakeGame.pid != null && game.pid === dqh._fakeGame.pid))) {
+                        remaining.splice(i, 1);
+                    }
+                }
             }
             if (dqh.FluxDispatcher && dqh._fakeGame) {
                 dqh.FluxDispatcher.dispatch({ type: "RUNNING_GAMES_CHANGE", removed: [dqh._fakeGame], added: [], games: remaining });
@@ -965,7 +1133,7 @@ const JS_CLEANUP_SPOOF: &str = r#"
         for (const name of names) {
             const dqh = window[name];
             if (!isDqhBridge(dqh)) continue;
-            cleanupOne(dqh, name);
+            await cleanupOne(dqh, name);
             cleaned++;
         }
         return JSON.stringify({ success: true, cleaned });
@@ -989,6 +1157,7 @@ const JS_VERIFY_CLEANUP_STATE: &str = r#"
                 || obj._spoofActive === true
                 || obj._fakeGame
                 || obj._origDispatch
+                || obj._origSetObservedGamesCallback
                 || (obj.initialized === true && obj.RunningGameStore)
             ));
         }
@@ -997,6 +1166,8 @@ const JS_VERIFY_CLEANUP_STATE: &str = r#"
         let fakeGamePresent = false;
         let hasDispatchHook = false;
         let broadPatchCount = 0;
+        let observerHook = false;
+        let fakeApplicationId = null;
         for (const name of names) {
             const dqh = window[name];
             if (!isDqhBridge(dqh)) continue;
@@ -1004,15 +1175,56 @@ const JS_VERIFY_CLEANUP_STATE: &str = r#"
             spoofActive = spoofActive || !!dqh._spoofActive;
             fakeGamePresent = fakeGamePresent || !!dqh._fakeGame;
             hasDispatchHook = hasDispatchHook || !!dqh._origDispatch;
+            observerHook = observerHook || !!dqh._origSetObservedGamesCallback;
             broadPatchCount += Array.isArray(dqh._broadPatched) ? dqh._broadPatched.length : 0;
+            if (!fakeApplicationId) fakeApplicationId = dqh._fakeApplicationId || (dqh._fakeGame && dqh._fakeGame.id) || null;
         }
+        let fakeInRunningGames = false;
+        let debugGamePresent = false;
+        try {
+            const webpackRequire = webpackChunkdiscord_app.push([[Symbol()], {}, r => r]);
+            webpackChunkdiscord_app.pop();
+            let store = null;
+            let nativeUtils = null;
+            for (const mod of Object.values(webpackRequire.c || {})) {
+                const exp = mod && mod.exports;
+                if (!exp) continue;
+                for (const key of Object.keys(exp)) {
+                    const val = exp[key];
+                    if (!store && typeof val?.getRunningGames === "function") {
+                        try {
+                            const games = val.getRunningGames();
+                            if (Array.isArray(games)) store = val;
+                        } catch(e) {}
+                    }
+                    if (!nativeUtils && typeof val?.getDiscordUtils === "function" && typeof val?.setObservedGamesCallback === "function" && typeof val?.setGameCandidateOverrides === "function") {
+                        nativeUtils = val;
+                    }
+                }
+            }
+            if (store) {
+                try {
+                    debugGamePresent = !!store.getDebugRunningGame?.();
+                    const games = store.getRunningGames() || [];
+                    if (fakeApplicationId) {
+                        fakeInRunningGames = games.some(g => g && String(g.id) === String(fakeApplicationId));
+                    }
+                } catch(e) {}
+            }
+            if (nativeUtils && nativeUtils.setObservedGamesCallback && nativeUtils.setObservedGamesCallback.toString && nativeUtils.setObservedGamesCallback.toString().includes("wrappedCb")) {
+                observerHook = true;
+            }
+        } catch(e) {}
         return JSON.stringify({
             success: true,
             dqhPresent,
             spoofActive,
             fakeGamePresent,
             hasDispatchHook,
-            broadPatchCount
+            broadPatchCount,
+            observerHook,
+            fakeInRunningGames,
+            debugGamePresent
         });
     } catch (e) {
         return JSON.stringify({ success: false, error: String(e) });
@@ -1673,7 +1885,7 @@ async fn cdp_cleanup_with_attempts(port: u16, max_attempts: u32) -> Result<()> {
     for attempt in 1..=max_attempts {
         let mut cleanup_success_count = 0usize;
 
-        match cdp_client::execute_js_via_all_discord_targets(port, &cleanup_js, false, 5).await {
+        match cdp_client::execute_js_via_all_discord_targets(port, &cleanup_js, true, 15).await {
             Ok(results) => {
                 let mut error_count = 0usize;
 
@@ -1744,6 +1956,19 @@ async fn cdp_cleanup_with_attempts(port: u16, max_attempts: u32) -> Result<()> {
                 let mut verify_errors = 0usize;
 
                 for item in results {
+                    if is_discord_auxiliary_page(&item.target_title, &item.target_url) {
+                        log(
+                            LogLevel::Debug,
+                            LogCategory::TokenExtraction,
+                            &format!(
+                                "CDP cleanup skipping overlay/popout verify (attempt {}): target='{}' url='{}'",
+                                attempt, item.target_title, item.target_url
+                            ),
+                            None,
+                        );
+                        continue;
+                    }
+
                     if let Some(err) = item.error {
                         verify_errors += 1;
                         log(LogLevel::Warn, LogCategory::TokenExtraction,
@@ -1775,7 +2000,7 @@ async fn cdp_cleanup_with_attempts(port: u16, max_attempts: u32) -> Result<()> {
                         verify_dirty += 1;
                         log(LogLevel::Warn, LogCategory::TokenExtraction,
                             &format!(
-                                "CDP cleanup verify found residual state (attempt {}): target='{}' url='{}' dqhPresent={} spoofActive={} fakeGamePresent={} hasDispatchHook={} broadPatchCount={}",
+                                "CDP cleanup verify found residual state (attempt {}): target='{}' url='{}' dqhPresent={} spoofActive={} fakeGamePresent={} hasDispatchHook={} broadPatchCount={} observerHook={} fakeInRunningGames={} debugGamePresent={}",
                                 attempt,
                                 item.target_title,
                                 item.target_url,
@@ -1783,7 +2008,10 @@ async fn cdp_cleanup_with_attempts(port: u16, max_attempts: u32) -> Result<()> {
                                 verify.spoof_active,
                                 verify.fake_game_present,
                                 verify.has_dispatch_hook,
-                                verify.broad_patch_count
+                                verify.broad_patch_count,
+                                verify.observer_hook,
+                                verify.fake_in_running_games,
+                                verify.debug_game_present
                             ),
                             None,
                         );
@@ -3769,13 +3997,75 @@ mod tests {
             "sku",
             "gameMetadata",
             "executableFingerprint",
+            "start",
+            "setObservedGamesCallback",
+            "GAMES_DATABASE_UPDATE",
         ] {
             assert!(js.contains(field), "missing live scanner field {field}");
         }
+        assert!(js.contains("lastFocused: 0") || js.contains("lastFocused:0"));
+        assert!(js.contains("start: Date.now()"));
+        assert!(js.contains("seenMatch.nativeProcessObserverId"));
+        assert!(js.contains("wrappedCb"));
+        assert!(!js.contains("nativeProcessObserverId: pid"));
+        assert!(!js.contains("Math.floor(Math.random() * 30000)"));
         assert!(js.contains("if (!Array.isArray(sample)) continue"));
         assert!(js.contains("patchVisibleAccessor"));
+        assert!(js.contains("patchedGetVisibleGame"));
+        assert!(js.contains("patchedGetCurrentGameForAnalytics"));
         assert!(js.contains(r#"split("{app}")"#));
         assert!(!js.contains(r#"split("{{app}}")"#));
+    }
+
+    #[test]
+    fn play_spoof_js_appends_synthetic_game_instead_of_replacing() {
+        let js = js_spoof_play_game_for("123", "Cool Game", DetectableOs::Win32, Vec::new());
+        assert!(js.contains("if (list.some(g => sameGame(g, fake))) return list"));
+        assert!(!js.contains("reuseNativeAndReturn"));
+        assert!(!js.contains("notifyGameLaunched"));
+        assert!(!js.contains("nativeAlreadyPresent"));
+        assert!(!js.contains("RUNNING_GAME_SET_DEBUG_GAME"));
+        assert!(js.contains("if (visible) return visible"));
+        assert!(js.contains("const already = Array.isArray(event.games)"));
+        assert!(js.contains("wrappedCb"));
+    }
+
+    #[test]
+    fn play_spoof_js_embeds_real_process_hints() {
+        let js = js_spoof_play_game_for(
+            "123",
+            "Cool Game",
+            DetectableOs::Win32,
+            vec![SimulatedProcessHint {
+                pid: 4242,
+                exe_name: "Cool Game.exe".into(),
+                exe_path: r"C:\Games\Cool Game.exe".into(),
+                cmd_line: r#""C:\Games\Cool Game.exe""#.into(),
+            }],
+        );
+        assert!(js.contains("4242"));
+        assert!(js.contains(r"C:\\Games\\Cool Game.exe") || js.contains(r"C:\Games\Cool Game.exe"));
+        assert!(js.contains("fakeGame.pid = hint.pid"));
+        assert!(js.contains("getWindowHandleFromPid"));
+        assert!(!js.contains("nativeProcessObserverId: pid"));
+    }
+
+    #[test]
+    fn overlay_and_popout_are_skipped_during_cleanup_verify() {
+        assert!(is_discord_auxiliary_page(
+            "Discord Overlay",
+            "https://discord.com/popout"
+        ));
+        assert!(is_discord_auxiliary_page(
+            "Friends",
+            "https://discord.com/popout"
+        ));
+        assert!(!is_discord_auxiliary_page(
+            "Friends",
+            "https://discord.com/channels/@me"
+        ));
+        assert!(JS_VERIFY_CLEANUP_STATE.contains("debugGamePresent"));
+        assert!(JS_VERIFY_CLEANUP_STATE.contains("getDebugRunningGame"));
     }
 
     #[test]
@@ -3851,6 +4141,128 @@ mod tests {
         assert!(!JS_CLEANUP_SPOOF.contains("games: []"));
         assert!(JS_CLEANUP_SPOOF.contains(r#"__" + "dqh_cdp""#));
         assert!(JS_CLEANUP_SPOOF.contains("^__n[0-9a-f]{10}$"));
+        assert!(JS_CLEANUP_SPOOF.contains("_origSetObservedGamesCallback"));
+        assert!(JS_CLEANUP_SPOOF.contains("GAMES_DATABASE_UPDATE"));
         assert!(JS_VERIFY_CLEANUP_STATE.contains("^__n[0-9a-f]{10}$"));
+        assert!(JS_VERIFY_CLEANUP_STATE.contains("observerHook"));
+        assert!(JS_VERIFY_CLEANUP_STATE.contains("fakeInRunningGames"));
+        assert!(JS_VERIFY_CLEANUP_STATE.contains("debugGamePresent"));
+        assert!(JS_INIT_QUEST_MODULES.contains("NativeUtils"));
+        assert!(JS_INIT_QUEST_MODULES.contains("DetectableGameStore"));
+        assert!(JS_INIT_QUEST_MODULES.contains("const DQH_INIT_VERSION = 7"));
+    }
+
+    fn snapshot_game_by_id<'a>(
+        snapshot: &'a crate::cdp_client::CdpRunningGamesSnapshot,
+        app_id: &str,
+    ) -> Option<&'a serde_json::Value> {
+        snapshot.games.iter().find(|game| game_id_is(game, app_id))
+    }
+
+    fn game_id_is(game: &serde_json::Value, app_id: &str) -> bool {
+        match game.get("id") {
+            Some(serde_json::Value::String(value)) => value == app_id,
+            Some(serde_json::Value::Number(value)) => value.to_string() == app_id,
+            _ => false,
+        }
+    }
+
+    fn json_id(value: Option<&serde_json::Value>) -> Option<String> {
+        value.and_then(|game| match game.get("id") {
+            Some(serde_json::Value::String(id)) => Some(id.clone()),
+            Some(serde_json::Value::Number(id)) => Some(id.to_string()),
+            _ => None,
+        })
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a live Discord CDP session on the default debugging port"]
+    async fn live_cdp_running_game_spoof_ab() {
+        let port = crate::cdp_client::DEFAULT_CDP_PORT;
+        let before = crate::cdp_client::fetch_running_games_via_cdp(port)
+            .await
+            .expect("Discord CDP snapshot should be reachable");
+        assert!(before.store_found, "RunningGameStore should be loaded");
+
+        let app_id = "1158877933042143272".to_string();
+        let app_name = "Counter-Strike 2".to_string();
+
+        let init = cdp_init_modules(port).await;
+        if init.is_err() {
+            let _ = cdp_cleanup_with_attempts(port, CDP_CLEANUP_ATTEMPTS).await;
+        }
+        init.expect("quest module init should succeed on the main renderer");
+
+        let spoof_js = with_bridge(&js_spoof_play_game(&app_id, &app_name));
+        let spoof_raw =
+            crate::cdp_client::execute_js_via_primary_discord_target(port, &spoof_js, true, 30)
+                .await;
+        let during = crate::cdp_client::fetch_running_games_via_cdp(port).await;
+        let cleanup = cdp_cleanup_with_attempts(port, CDP_CLEANUP_ATTEMPTS).await;
+        let after = crate::cdp_client::fetch_running_games_via_cdp(port).await;
+
+        let spoof_raw = spoof_raw.expect("spoof JS should execute");
+        let spoof_parsed: serde_json::Value =
+            serde_json::from_str(&spoof_raw).expect("spoof JS should return JSON");
+        assert_eq!(
+            spoof_parsed.get("success"),
+            Some(&serde_json::json!(true)),
+            "spoof failed: {spoof_raw}"
+        );
+        assert_eq!(
+            spoof_parsed.get("wrappedObserver"),
+            Some(&serde_json::json!(true)),
+            "spoof should wrap setObservedGamesCallback: {spoof_raw}"
+        );
+        cleanup.expect("cleanup should succeed even if Overlay/popout targets exist");
+
+        let during = during.expect("snapshot during spoof");
+        let after = after.expect("snapshot after cleanup");
+        assert_eq!(json_id(during.games.first()), Some(app_id.clone()));
+        assert_eq!(json_id(during.visible_game.as_ref()), Some(app_id.clone()));
+        assert_eq!(
+            json_id(during.analytics_game.as_ref()),
+            Some(app_id.clone())
+        );
+        let spoofed = snapshot_game_by_id(&during, &app_id).expect("spoofed game");
+        assert_eq!(spoofed.get("lastFocused"), Some(&serde_json::json!(0)));
+        assert!(spoofed
+            .get("start")
+            .and_then(|value| value.as_u64())
+            .is_some());
+        let pid = spoofed.get("pid");
+        assert!(
+            pid.is_none()
+                || pid == Some(&serde_json::Value::Null)
+                || pid == Some(&serde_json::json!("<undefined>")),
+            "spoof must not invent a pid"
+        );
+        assert!(
+            snapshot_game_by_id(&after, &app_id).is_none(),
+            "cleanup must remove the synthetic running game"
+        );
+
+        let verify_raw = crate::cdp_client::execute_js_via_primary_discord_target(
+            port,
+            &with_bridge(JS_VERIFY_CLEANUP_STATE),
+            false,
+            5,
+        )
+        .await;
+        let verify_raw = verify_raw.expect("cleanup verify should execute");
+        let verify_parsed: serde_json::Value =
+            serde_json::from_str(&verify_raw).expect("cleanup verify should return JSON");
+        let verify =
+            cleanup_verify_from_json(&verify_parsed).expect("cleanup verify should report success");
+        assert!(
+            cleanup_verify_is_clean(&verify),
+            "main renderer still dirty after cleanup: {verify_raw}"
+        );
+        assert!(
+            after.debug_game.is_none()
+                || after.debug_game == Some(serde_json::Value::Null)
+                || after.debug_game == Some(serde_json::json!("<undefined>")),
+            "getDebugRunningGame must stay unset"
+        );
     }
 }

--- a/src-tauri/src/cdp_quest.rs
+++ b/src-tauri/src/cdp_quest.rs
@@ -1115,12 +1115,17 @@ const JS_CLEANUP_SPOOF: &str = r#"
             }
             if (!Array.isArray(remaining)) remaining = [];
             if (dqh._fakeGame) {
-                remaining = remaining.filter(game =>
-                    !game || (
-                        String(game.id) !== String(dqh._fakeGame.id)
-                        && (dqh._fakeGame.pid == null || game.pid !== dqh._fakeGame.pid)
-                    )
-                );
+                remaining = remaining.filter(game => {
+                    if (!game) return true;
+                    if (game === dqh._fakeGame) return false;
+                    const sameId = String(game.id) === String(dqh._fakeGame.id);
+                    const samePid = dqh._fakeGame.pid != null && game.pid === dqh._fakeGame.pid;
+                    if (samePid) return false;
+                    // Same application with no pid is the injected row. A genuine
+                    // native detection of that application keeps a real pid.
+                    if (sameId && (game.pid == null || game.pid === undefined)) return false;
+                    return true;
+                });
             }
             if (dqh.FluxDispatcher && dqh._fakeGame) {
                 dqh.FluxDispatcher.dispatch({ type: "RUNNING_GAMES_CHANGE", removed: [dqh._fakeGame], added: [], games: remaining });
@@ -4185,6 +4190,7 @@ mod tests {
         assert!(!JS_CLEANUP_SPOOF.contains("games: []"));
         assert!(JS_CLEANUP_SPOOF.contains("remaining = remaining.filter"));
         assert!(!JS_CLEANUP_SPOOF.contains("remaining.splice"));
+        assert!(JS_CLEANUP_SPOOF.contains("sameId && (game.pid == null || game.pid === undefined)"));
         assert!(JS_CLEANUP_SPOOF.contains("needsObserverSettle"));
         assert!(JS_CLEANUP_SPOOF.contains(r#"__" + "dqh_cdp""#));
         assert!(JS_CLEANUP_SPOOF.contains("^__n[0-9a-f]{10}$"));

--- a/src-tauri/src/game_simulator.rs
+++ b/src-tauri/src/game_simulator.rs
@@ -580,6 +580,8 @@ fn untrack_running_game(executable_name: &str) {
 }
 
 /// Snapshot of simulated-game processes that CDP spoof can reuse as a real PID/path.
+/// Linux tracks exact child PIDs; Windows/macOS launch via `cmd /C start` / `open`
+/// and do not keep a pid, so they return no hints.
 pub fn simulated_process_hints() -> Vec<crate::cdp_game_spoof::SimulatedProcessHint> {
     #[cfg(target_os = "linux")]
     {

--- a/src/api/tauri.ts
+++ b/src/api/tauri.ts
@@ -455,6 +455,10 @@ export interface CdpRunningGamesSnapshot {
   native_module_methods: string[]
   games: Array<Record<string, unknown>>
   visible_games: Array<Record<string, unknown>>
+  visible_game?: Record<string, unknown> | null
+  analytics_game?: Record<string, unknown> | null
+  debug_game?: Record<string, unknown> | null
+  store_views_diff?: Record<string, unknown> | null
   native_diagnostics: Array<Record<string, unknown>>
   errors: string[]
 }

--- a/src/views/Debug.vue
+++ b/src/views/Debug.vue
@@ -700,6 +700,21 @@ onMounted(() => {
               <pre class="max-h-96 overflow-auto rounded bg-muted p-3 text-xs whitespace-pre-wrap break-all">{{ JSON.stringify(runningGamesSnapshot.visible_games, null, 2) }}</pre>
             </div>
 
+            <div v-if="runningGamesSnapshot.store_views_diff" class="space-y-2">
+              <div class="text-sm font-medium">store_views_diff</div>
+              <pre class="max-h-96 overflow-auto rounded bg-muted p-3 text-xs whitespace-pre-wrap break-all">{{ JSON.stringify(runningGamesSnapshot.store_views_diff, null, 2) }}</pre>
+            </div>
+
+            <div v-if="runningGamesSnapshot.visible_game" class="space-y-2">
+              <div class="text-sm font-medium">getVisibleGame</div>
+              <pre class="max-h-96 overflow-auto rounded bg-muted p-3 text-xs whitespace-pre-wrap break-all">{{ JSON.stringify(runningGamesSnapshot.visible_game, null, 2) }}</pre>
+            </div>
+
+            <div v-if="runningGamesSnapshot.analytics_game" class="space-y-2">
+              <div class="text-sm font-medium">getCurrentGameForAnalytics</div>
+              <pre class="max-h-96 overflow-auto rounded bg-muted p-3 text-xs whitespace-pre-wrap break-all">{{ JSON.stringify(runningGamesSnapshot.analytics_game, null, 2) }}</pre>
+            </div>
+
             <details>
               <summary class="cursor-pointer text-sm font-medium">{{ t('debug.running_games_module_methods') }}</summary>
               <pre class="mt-2 max-h-64 overflow-auto rounded bg-muted p-3 text-xs whitespace-pre-wrap break-all">{{ JSON.stringify(runningGamesSnapshot.native_module_methods, null, 2) }}</pre>


### PR DESCRIPTION
## Summary
- Inject the synthetic running game by wrapping `setObservedGamesCallback` and re-registering with `GAMES_DATABASE_UPDATE`, so Discord's own `J` / `en` / `ei` path sees the spoof instead of only patched getters.
- Align the spoofed object with the live scanner schema (`start`, `lastFocused: 0`, no invented pid or fingerprint) and keep getter patches as a fallback.
- Treat Overlay/popout CDP verify failures as non-dirty so cleanup can succeed when the main renderer is clean. Debug snapshots now include `getVisibleGame` / `getCurrentGameForAnalytics` for confirmation.

## Test plan
- [ ] `cargo test --lib` in `src-tauri` (and launch-core) passes.
- [ ] Idle Discord on `:9223`: start a CDP play quest for an uninstalled game; `getRunningGames`, `getVisibleGame`, and `getCurrentGameForAnalytics` all show the spoofed id.
- [ ] Stop the quest: those three views are empty, no leftover `__n*` bridge, `getDebugRunningGame()` is null.
- [ ] With Discord Overlay/popout open, stopping a CDP quest still reports cleanup success if the main renderer is clean.
- [ ] Debug page running-games snapshot shows `store_views_diff` plus visible/analytics games.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Integrate Discord’s native running-game observer into the CDP quest spoofing flow, improve cleanup verification, and expand running-game diagnostics.

New Features:
- Capture and wrap Discord’s NativeUtils observer to inject synthetic running games so core store views (including analytics and visibility) see the spoofed title.
- Expose additional running-game snapshot fields (single visible game, analytics game, debug game, and store view diffs) and surface them in the debug UI.

Bug Fixes:
- Ensure cleanup treats overlay/popout auxiliary Discord pages as non-dirty while still verifying the main renderer’s state.
- Prevent duplicate synthetic entries by appending spoofed games only when the application ID or PID is absent in existing running games.

Enhancements:
- Align spoofed running-game objects with the live scanner schema by using `start` timestamps, neutral `lastFocused`, and real process hints without inventing PIDs.
- Strengthen cleanup verification by tracking observer hooks, residual synthetic games, and debug-game presence, and by restoring patched store methods and native observers.
- Increase robustness of CDP cleanup by awaiting async dispatches across all Discord targets and extending timeouts for JS execution.
- Clarify platform behavior for simulated process hints, documenting PID availability differences between Linux and other OSes.

Tests:
- Add unit and integration tests around spoof JS behavior, schema alignment, cleanup correctness, auxiliary-page handling, and overlay target selection.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR routes synthetic running-game activity through Discord’s native observer, expands store-view diagnostics, and strengthens teardown verification.
- Wraps and restores the native observed-games callback.
- Aligns synthetic game fields with the scanner schema and prioritizes the quest target in visible and analytics getters.
- Preserves legitimate PID-backed activity during cleanup and ignores auxiliary-page verification failures.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains in the previously reported areas.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/cdp_quest.rs | Adds native-observer spoofing, synthetic-first single-game getters, scoped cleanup verification, and restoration that preserves PID-backed native activity. |
| src-tauri/src/cdp_game_spoof.rs | Extends cleanup verification state and updates synthetic game schema and merge behavior. |
| src-tauri/src/cdp_client.rs | Expands running-game diagnostics with visible, analytics, debug, and cross-view comparison data. |
| crates/discord-cdp-launch-core/src/cdp.rs | Exposes auxiliary Discord-page classification used to distinguish overlay and popout targets. |
| src/views/Debug.vue | Surfaces the expanded running-game diagnostics in the debug interface. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as Quest Helper
    participant CDP as Discord Renderer
    participant Observer as Native Game Observer
    participant Store as RunningGameStore
    App->>CDP: Inject spoof and wrap observer
    Observer->>CDP: Report observed games
    CDP->>Store: Append synthetic game and dispatch update
    Store-->>App: Visible/analytics quest game
    App->>CDP: Cleanup spoof
    CDP->>Observer: Restore original callback
    CDP->>Store: Dispatch remaining native games
    App->>CDP: Verify hooks and synthetic state removed
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(cdp): keep native running games when..."](https://github.com/masterain98/discord-quest-helper/commit/26ccc2be0f425651fbfca3a2613d3a23e1776e45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53941796)</sub>

<!-- /greptile_comment -->