### PR TITLE
feat(windows): shrink Discord-visible process signature of stealth copies

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,7 +46,10 @@ windows = { version = "0.62", features = [
     "Win32_Security_Cryptography",
     "Win32_Foundation",
     "Win32_Globalization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_LibraryLoader",
     "Win32_UI_HiDpi",
+    "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
     "Storage_Streams",
 ] }

--- a/src-tauri/src/game_simulator.rs
+++ b/src-tauri/src/game_simulator.rs
@@ -215,8 +215,10 @@ pub fn run_simulated_game(
         anyhow::bail!("Executable does not exist: {:?}", exe_to_run);
     }
 
-    let _ = Command::new("cmd")
-        .args(["/C", "start", "", exe_to_run.to_str().unwrap()])
+    use std::os::windows::process::CommandExt;
+
+    let _ = Command::new(&exe_to_run)
+        .creation_flags(simulated_game_spawn_flags())
         .spawn()
         .context("Could not start simulated game")?;
 
@@ -579,8 +581,17 @@ fn untrack_running_game(executable_name: &str) {
     }
 }
 
+/// DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP. No CREATE_NO_WINDOW — the
+/// runner needs a visible window. No `cmd /C start`.
+#[cfg(any(windows, test))]
+pub(crate) fn simulated_game_spawn_flags() -> u32 {
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+    const DETACHED_PROCESS: u32 = 0x0000_0008;
+    CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
+}
+
 /// Snapshot of simulated-game processes that CDP spoof can reuse as a real PID/path.
-/// Linux tracks exact child PIDs; Windows/macOS launch via `cmd /C start` / `open`
+/// Linux tracks exact child PIDs; Windows/macOS launch detached / via `open`
 /// and do not keep a pid, so they return no hints.
 pub fn simulated_process_hints() -> Vec<crate::cdp_game_spoof::SimulatedProcessHint> {
     #[cfg(target_os = "linux")]
@@ -694,5 +705,15 @@ mod tests {
             }
             Err(e) => println!("Test skipped (expected): {}", e),
         }
+    }
+
+    #[test]
+    fn windows_game_spawn_flags_are_detached_without_hidden_window() {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        let flags = simulated_game_spawn_flags();
+        assert_eq!(flags, DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+        assert_eq!(flags & CREATE_NO_WINDOW, 0);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,9 @@ mod models;
 mod platform_capabilities;
 mod quest_completer;
 mod stealth;
+#[cfg(windows)]
+#[cfg_attr(debug_assertions, allow(dead_code))]
+mod stealth_pe;
 mod super_properties;
 mod token_extractor;
 
@@ -23,7 +26,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use super_properties::XSuperPropertiesManager;
 use tauri::ipc::Channel;
-use tauri::{Emitter, Listener, Manager, State};
+use tauri::{Emitter, Listener, Manager, State, WebviewWindowBuilder};
 
 /// Global X-Super-Properties manager (session-level)
 /// Automatically generates key validation fields, fetches latest version info from Discord after login
@@ -1606,6 +1609,7 @@ pub fn ensure_stealth_and_run() {
 
     // Try to enter stealth mode
     stealth::ensure_stealth_mode();
+    stealth::apply_process_identity();
 
     // Set up cleanup hook for panics with recursion guard
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -1708,6 +1712,31 @@ mod linux_webkit_runtime_tests {
     }
 }
 
+fn create_main_window(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    let window_config = app
+        .config()
+        .app
+        .windows
+        .first()
+        .cloned()
+        .ok_or("missing window configuration")?;
+
+    let mut builder = WebviewWindowBuilder::from_config(app.handle(), &window_config)?;
+
+    if stealth::is_stealth_mode() {
+        let title = stealth::generate_stealth_window_title();
+        builder = builder.title(&title);
+        if let Some(user_data) = stealth::webview_user_data_dir() {
+            std::fs::create_dir_all(&user_data)?;
+            builder = builder.data_directory(user_data);
+        }
+        builder = builder.icon(tauri::image::Image::new_owned(vec![0, 0, 0, 0], 1, 1))?;
+    }
+
+    builder.build()?;
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -1742,19 +1771,7 @@ pub fn run() {
                 });
             }
 
-            // Set random window title in stealth mode
-            if stealth::is_stealth_mode() {
-                if let Some(window) = app.get_webview_window("main") {
-                    let stealth_title = stealth::generate_stealth_window_title();
-                    println!("[Stealth] Setting window title to: {}", stealth_title);
-                    if let Err(err) = window.set_title(&stealth_title) {
-                        eprintln!(
-                            "[Stealth] Failed to set window title to '{}': {}",
-                            stealth_title, err
-                        );
-                    }
-                }
-            }
+            create_main_window(app)?;
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -2240,6 +2257,23 @@ async fn install_discord_cdp_launcher_internal(
         })?;
     }
 
+    stealth::strip_zone_identifier(&target);
+
+    #[cfg(windows)]
+    {
+        if let (Some(file_name), Some(stem)) = (
+            target.file_name().and_then(|n| n.to_str()),
+            target.file_stem().and_then(|n| n.to_str()),
+        ) {
+            if let Err(err) = stealth_pe::rewrite_copy_identity(&target, file_name, stem) {
+                eprintln!("[cdp-launcher-install] Failed to rewrite version info: {err}");
+            }
+        }
+        if let Some(local_appdata) = std::env::var_os("LOCALAPPDATA") {
+            migrate_legacy_windows_cdp_launcher_at(std::path::Path::new(&local_appdata), &target);
+        }
+    }
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -2255,9 +2289,11 @@ fn stable_cdp_launcher_path() -> Result<std::path::PathBuf, String> {
     {
         let local_appdata = std::env::var_os("LOCALAPPDATA")
             .ok_or_else(|| "Could not get LOCALAPPDATA".to_string())?;
-        Ok(std::path::PathBuf::from(local_appdata)
-            .join("DiscordQuestHelper")
-            .join("DiscordCdpLauncher.exe"))
+        let pointer = windows_cdp_runtime_pointer_path()?;
+        Ok(resolve_windows_cdp_runtime_path(
+            std::path::Path::new(&local_appdata),
+            &pointer,
+        ))
     }
 
     #[cfg(target_os = "macos")]
@@ -2282,6 +2318,131 @@ fn stable_cdp_launcher_path() -> Result<std::path::PathBuf, String> {
     {
         Err("Discord CDP launcher is only supported on Windows, macOS and Linux.".to_string())
     }
+}
+
+#[cfg(any(windows, test))]
+const WINDOWS_CDP_APP_CONFIG_DIR: &str = "com.masterain.discord-quest-helper";
+#[cfg(any(windows, test))]
+const WINDOWS_CDP_RUNTIME_POINTER: &str = "cdp-runtime-exe.txt";
+#[cfg(any(windows, test))]
+const WINDOWS_LEGACY_CDP_DIR: &str = "DiscordQuestHelper";
+#[cfg(any(windows, test))]
+const WINDOWS_LEGACY_CDP_EXE: &str = "DiscordCdpLauncher.exe";
+
+#[cfg(any(windows, test))]
+fn windows_cdp_runtime_pointer_path_from(appdata: &std::path::Path) -> std::path::PathBuf {
+    appdata
+        .join(WINDOWS_CDP_APP_CONFIG_DIR)
+        .join(WINDOWS_CDP_RUNTIME_POINTER)
+}
+
+#[cfg(windows)]
+fn windows_cdp_runtime_pointer_path() -> Result<std::path::PathBuf, String> {
+    let appdata = std::env::var_os("APPDATA").ok_or_else(|| "Could not get APPDATA".to_string())?;
+    Ok(windows_cdp_runtime_pointer_path_from(std::path::Path::new(
+        &appdata,
+    )))
+}
+
+#[cfg(any(windows, test))]
+fn same_path(a: &std::path::Path, b: &std::path::Path) -> bool {
+    if a == b {
+        return true;
+    }
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => a == b,
+    }
+}
+
+/// `%LOCALAPPDATA%/<16 hex>/<12 hex>.exe` — layout only, not a full-path
+/// substring scan (user profile names can contain product tokens).
+#[cfg(any(windows, test))]
+fn is_windows_bland_runtime_exe(path: &std::path::Path, local_appdata: &std::path::Path) -> bool {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("exe") => {}
+        _ => return false,
+    }
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    if !stealth::is_hex_str(stem, stealth::FILE_HEX_LEN) {
+        return false;
+    }
+    let parent = match path.parent() {
+        Some(dir) => dir,
+        None => return false,
+    };
+    let parent_name = parent.file_name().and_then(|s| s.to_str()).unwrap_or("");
+    if !stealth::is_hex_str(parent_name, stealth::DIR_HEX_LEN) {
+        return false;
+    }
+    let Some(grandparent) = parent.parent() else {
+        return false;
+    };
+    same_path(grandparent, local_appdata)
+}
+
+#[cfg(any(windows, test))]
+fn allocate_windows_bland_runtime_exe(local_appdata: &std::path::Path) -> std::path::PathBuf {
+    local_appdata
+        .join(stealth::generate_random_suffix(stealth::DIR_HEX_LEN))
+        .join(format!(
+            "{}.exe",
+            stealth::generate_random_suffix(stealth::FILE_HEX_LEN)
+        ))
+}
+
+#[cfg(any(windows, test))]
+fn resolve_windows_cdp_runtime_path(
+    local_appdata: &std::path::Path,
+    pointer_file: &std::path::Path,
+) -> std::path::PathBuf {
+    if let Ok(stored) = std::fs::read_to_string(pointer_file) {
+        let stored = std::path::PathBuf::from(stored.trim());
+        if is_windows_bland_runtime_exe(&stored, local_appdata) && stored.is_file() {
+            return stored;
+        }
+    }
+    let next = allocate_windows_bland_runtime_exe(local_appdata);
+    if let Some(parent) = pointer_file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(pointer_file, next.to_string_lossy().as_bytes());
+    next
+}
+
+#[cfg(any(windows, test))]
+fn migrate_legacy_windows_cdp_launcher_at(
+    local_appdata: &std::path::Path,
+    new_target: &std::path::Path,
+) {
+    let old_dir = local_appdata.join(WINDOWS_LEGACY_CDP_DIR);
+    let old_exe = old_dir.join(WINDOWS_LEGACY_CDP_EXE);
+    if old_exe.is_file() && !new_target.exists() {
+        if let Some(parent) = new_target.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::copy(&old_exe, new_target);
+    }
+    if old_dir.exists() {
+        let _ = std::fs::remove_dir_all(&old_dir);
+    }
+}
+
+#[cfg(any(windows, test))]
+fn windows_shortcut_temp_ps1_name() -> String {
+    format!(
+        "{}.ps1",
+        stealth::generate_random_suffix(stealth::DIR_HEX_LEN)
+    )
+}
+
+#[cfg(test)]
+fn runtime_name_has_product_tokens(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.contains("discord")
+        || lower.contains("quest")
+        || lower.contains("cdp")
+        || lower.contains("helper")
 }
 
 #[cfg(target_os = "linux")]
@@ -2525,10 +2686,7 @@ $Shortcut.Save()
         shortcut_path = shortcut_path_ps,
     );
 
-    let script_path = std::env::temp_dir().join(format!(
-        "discord_cdp_launcher_shortcut_{}.ps1",
-        uuid::Uuid::new_v4()
-    ));
+    let script_path = std::env::temp_dir().join(windows_shortcut_temp_ps1_name());
     std::fs::write(&script_path, &ps_script)
         .map_err(|e| format!("Failed to write temporary PowerShell script: {}", e))?;
 
@@ -2771,5 +2929,151 @@ Exec="/opt/Discord Quest Helper/discord-cdp-launcher" --port 9444 --channel cana
             linux_cdp_launcher_options_from_desktop(desktop),
             (super::cdp_client::DEFAULT_CDP_PORT, None)
         );
+    }
+}
+
+#[cfg(test)]
+mod windows_cdp_runtime_path_tests {
+    use super::*;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    fn unique_root() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "dqh-cdp-runtime-{}",
+            stealth::generate_random_suffix(8)
+        ))
+    }
+
+    fn assert_bland_leaves(path: &Path) {
+        let file = path.file_stem().and_then(|s| s.to_str()).unwrap();
+        let dir = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .unwrap();
+        assert!(stealth::is_hex_str(dir, stealth::DIR_HEX_LEN), "{dir}");
+        assert!(stealth::is_hex_str(file, stealth::FILE_HEX_LEN), "{file}");
+        assert!(!runtime_name_has_product_tokens(dir));
+        assert!(!runtime_name_has_product_tokens(file));
+        assert!(!runtime_name_has_product_tokens(&format!("{file}.exe")));
+    }
+
+    #[test]
+    fn pointer_file_uses_app_config_dir() {
+        let pointer = windows_cdp_runtime_pointer_path_from(Path::new("/roaming"));
+        assert_eq!(
+            pointer.file_name().and_then(|n| n.to_str()),
+            Some(WINDOWS_CDP_RUNTIME_POINTER)
+        );
+        assert_eq!(
+            pointer
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str()),
+            Some(WINDOWS_CDP_APP_CONFIG_DIR)
+        );
+    }
+
+    #[test]
+    fn allocates_hex_layout_without_product_names() {
+        let root = unique_root();
+        let local = root.join("Local");
+        let pointer = windows_cdp_runtime_pointer_path_from(&root.join("Roaming"));
+        fs::create_dir_all(&local).unwrap();
+        let path = resolve_windows_cdp_runtime_path(&local, &pointer);
+        assert_bland_leaves(&path);
+        assert_eq!(
+            path.parent().and_then(|p| p.parent()),
+            Some(local.as_path())
+        );
+        let stored = fs::read_to_string(&pointer).unwrap();
+        assert_eq!(PathBuf::from(stored.trim()), path);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn reuses_pointer_when_file_still_exists() {
+        let root = unique_root();
+        let local = root.join("Local");
+        let pointer = windows_cdp_runtime_pointer_path_from(&root.join("Roaming"));
+        fs::create_dir_all(&local).unwrap();
+        let first = resolve_windows_cdp_runtime_path(&local, &pointer);
+        fs::create_dir_all(first.parent().unwrap()).unwrap();
+        fs::write(&first, b"exe").unwrap();
+        let second = resolve_windows_cdp_runtime_path(&local, &pointer);
+        assert_eq!(first, second);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn reallocates_when_pointer_target_is_missing() {
+        let root = unique_root();
+        let local = root.join("Local");
+        let pointer = windows_cdp_runtime_pointer_path_from(&root.join("Roaming"));
+        fs::create_dir_all(&local).unwrap();
+        let first = resolve_windows_cdp_runtime_path(&local, &pointer);
+        let second = resolve_windows_cdp_runtime_path(&local, &pointer);
+        assert_ne!(first, second);
+        assert_bland_leaves(&second);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn ignores_legacy_product_path_in_pointer() {
+        let root = unique_root();
+        let local = root.join("Local");
+        let pointer = windows_cdp_runtime_pointer_path_from(&root.join("Roaming"));
+        fs::create_dir_all(pointer.parent().unwrap()).unwrap();
+        fs::create_dir_all(&local).unwrap();
+        let legacy = local
+            .join(WINDOWS_LEGACY_CDP_DIR)
+            .join(WINDOWS_LEGACY_CDP_EXE);
+        fs::write(&pointer, legacy.to_string_lossy().as_bytes()).unwrap();
+        let path = resolve_windows_cdp_runtime_path(&local, &pointer);
+        assert!(is_windows_bland_runtime_exe(&path, &local));
+        assert_bland_leaves(&path);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn migrates_legacy_discord_quest_helper_dir() {
+        let root = unique_root();
+        let local = root.join("Local");
+        let old_dir = local.join(WINDOWS_LEGACY_CDP_DIR);
+        fs::create_dir_all(&old_dir).unwrap();
+        fs::write(old_dir.join(WINDOWS_LEGACY_CDP_EXE), b"old").unwrap();
+        let new_target = allocate_windows_bland_runtime_exe(&local);
+        migrate_legacy_windows_cdp_launcher_at(&local, &new_target);
+        assert!(!old_dir.exists());
+        assert!(new_target.is_file());
+        assert_eq!(fs::read(&new_target).unwrap(), b"old");
+        assert_bland_leaves(&new_target);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn migrate_does_not_overwrite_existing_target() {
+        let root = unique_root();
+        let local = root.join("Local");
+        let old_dir = local.join(WINDOWS_LEGACY_CDP_DIR);
+        fs::create_dir_all(&old_dir).unwrap();
+        fs::write(old_dir.join(WINDOWS_LEGACY_CDP_EXE), b"old").unwrap();
+        let new_target = allocate_windows_bland_runtime_exe(&local);
+        fs::create_dir_all(new_target.parent().unwrap()).unwrap();
+        fs::write(&new_target, b"new").unwrap();
+        migrate_legacy_windows_cdp_launcher_at(&local, &new_target);
+        assert!(!old_dir.exists());
+        assert_eq!(fs::read(&new_target).unwrap(), b"new");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn shortcut_temp_script_is_hex_named() {
+        let name = windows_shortcut_temp_ps1_name();
+        let stem = name.strip_suffix(".ps1").unwrap();
+        assert!(stealth::is_hex_str(stem, stealth::DIR_HEX_LEN));
+        assert!(!runtime_name_has_product_tokens(&name));
+        assert!(!name.to_ascii_lowercase().contains("discord"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2344,17 +2344,6 @@ fn windows_cdp_runtime_pointer_path() -> Result<std::path::PathBuf, String> {
     )))
 }
 
-#[cfg(any(windows, test))]
-fn same_path(a: &std::path::Path, b: &std::path::Path) -> bool {
-    if a == b {
-        return true;
-    }
-    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
-        (Ok(left), Ok(right)) => left == right,
-        _ => a == b,
-    }
-}
-
 /// `%LOCALAPPDATA%/<16 hex>/<12 hex>.exe` — layout only, not a full-path
 /// substring scan (user profile names can contain product tokens).
 #[cfg(any(windows, test))]
@@ -2378,7 +2367,7 @@ fn is_windows_bland_runtime_exe(path: &std::path::Path, local_appdata: &std::pat
     let Some(grandparent) = parent.parent() else {
         return false;
     };
-    same_path(grandparent, local_appdata)
+    stealth::paths_eq(grandparent, local_appdata)
 }
 
 #[cfg(any(windows, test))]

--- a/src-tauri/src/stealth.rs
+++ b/src-tauri/src/stealth.rs
@@ -534,10 +534,8 @@ mod tests {
 
     #[test]
     fn window_title_matches_stem() {
-        assert_eq!(
-            window_title_for_exe(Path::new(r"C:\Temp\abc\c0ffee12beef.exe")),
-            "c0ffee12beef"
-        );
+        let exe = PathBuf::from("abc").join("c0ffee12beef.exe");
+        assert_eq!(window_title_for_exe(&exe), "c0ffee12beef");
         assert_eq!(generate_random_suffix(12).len(), FILE_HEX_LEN);
         let suffix = generate_random_suffix(16);
         assert!(is_hex_str(&suffix, DIR_HEX_LEN));

--- a/src-tauri/src/stealth.rs
+++ b/src-tauri/src/stealth.rs
@@ -53,11 +53,14 @@ pub(crate) fn is_hex_str(s: &str, len: usize) -> bool {
 pub(crate) fn strip_zone_identifier(path: &Path) {
     #[cfg(target_os = "windows")]
     {
-        use windows::core::HSTRING;
+        use std::os::windows::ffi::OsStrExt;
+        use windows::core::PCWSTR;
         use windows::Win32::Storage::FileSystem::DeleteFileW;
 
-        let ads = format!("{}:Zone.Identifier", path.display());
-        let _ = unsafe { DeleteFileW(&HSTRING::from(ads.as_str())) };
+        let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+        wide.extend(":Zone.Identifier".encode_utf16());
+        wide.push(0);
+        let _ = unsafe { DeleteFileW(PCWSTR(wide.as_ptr())) };
     }
     #[cfg(not(target_os = "windows"))]
     {
@@ -65,7 +68,10 @@ pub(crate) fn strip_zone_identifier(path: &Path) {
     }
 }
 
-fn paths_eq(a: &Path, b: &Path) -> bool {
+pub(crate) fn paths_eq(a: &Path, b: &Path) -> bool {
+    if a == b {
+        return true;
+    }
     match (fs::canonicalize(a), fs::canonicalize(b)) {
         (Ok(left), Ok(right)) => left == right,
         _ => a == b,
@@ -157,17 +163,21 @@ fn remove_legacy_temp_file_if_needed(path: &Path) {
     }
 }
 
-fn dir_looks_like_stealth_copy(dir: &Path) -> bool {
+fn dir_contains_hex_stealth_exe(dir: &Path) -> bool {
     let Ok(entries) = fs::read_dir(dir) else {
         return false;
     };
     entries.flatten().any(|entry| {
         let path = entry.path();
-        if !path.is_file() {
-            return false;
-        }
-        is_stealth_copy_path(&path)
+        path.is_file() && is_stealth_copy_path(&path)
     })
+}
+
+/// Owned stealth trees also have the WebView2 `ud/` directory. Requiring that
+/// marker avoids deleting unrelated `%TEMP%/<16 hex>/` folders that happen to
+/// contain a 12-hex executable.
+fn dir_looks_like_stealth_copy(dir: &Path) -> bool {
+    dir.join(WEBVIEW_DATA_DIR_NAME).is_dir() && dir_contains_hex_stealth_exe(dir)
 }
 
 /// Check if currently running in stealth mode
@@ -195,11 +205,8 @@ pub fn webview_user_data_dir() -> Option<PathBuf> {
 
 /// Set process identity that windowing APIs read before the first window.
 pub fn apply_process_identity() {
-    if !is_stealth_mode() {
-        return;
-    }
     #[cfg(target_os = "windows")]
-    {
+    if is_stealth_mode() {
         let app_id = generate_stealth_window_title();
         let app_id = windows::core::HSTRING::from(app_id.as_str());
         if let Err(err) =
@@ -457,11 +464,19 @@ fn remove_tree_best_effort(path: &Path) {
 
 #[cfg(target_os = "windows")]
 fn mark_delete_on_reboot(path: &Path) {
-    use windows::core::{HSTRING, PCWSTR};
+    use std::os::windows::ffi::OsStrExt;
+    use windows::core::PCWSTR;
     use windows::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_DELAY_UNTIL_REBOOT};
 
-    let existing = HSTRING::from(path.to_string_lossy().as_ref());
-    let _ = unsafe { MoveFileExW(&existing, PCWSTR::null(), MOVEFILE_DELAY_UNTIL_REBOOT) };
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    wide.push(0);
+    let _ = unsafe {
+        MoveFileExW(
+            PCWSTR(wide.as_ptr()),
+            PCWSTR::null(),
+            MOVEFILE_DELAY_UNTIL_REBOOT,
+        )
+    };
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -540,6 +555,8 @@ mod tests {
         let exe = dir.join(&exe_name);
         fs::write(&exe, b"test").unwrap();
         assert!(is_stealth_copy_path(&exe));
+        assert!(!dir_looks_like_stealth_copy(&dir));
+        fs::create_dir_all(dir.join(WEBVIEW_DATA_DIR_NAME)).unwrap();
         assert!(dir_looks_like_stealth_copy(&dir));
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/stealth.rs
+++ b/src-tauri/src/stealth.rs
@@ -1,8 +1,8 @@
 //! Stealth Mode Module
 //!
-//! Implements runtime random process name for the main application
-//! to evade Discord detection. The main program uses a randomly
-//! generated filename when running.
+//! Release builds copy the main executable into a randomly named temp
+//! directory and relaunch from that copy so Discord's process scanner does
+//! not see the installed product name.
 
 #![cfg_attr(any(debug_assertions, target_os = "linux"), allow(dead_code))]
 
@@ -13,14 +13,19 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// Main app random name prefix
-const MAIN_APP_PREFIX: &str = "svc_";
+/// Hex directory name length under `temp_dir`.
+pub(crate) const DIR_HEX_LEN: usize = 16;
+/// Hex executable stem length inside the stealth directory.
+pub(crate) const FILE_HEX_LEN: usize = 12;
+/// Legacy prefix from the previous `svc_<hex>.exe` layout.
+const LEGACY_SVC_PREFIX: &str = "svc_";
+const WEBVIEW_DATA_DIR_NAME: &str = "ud";
 
 /// Flag indicating if current process is running in stealth mode
 static IS_STEALTH_MODE: AtomicBool = AtomicBool::new(false);
 
 /// Generate random hexadecimal string
-fn generate_random_suffix(length: usize) -> String {
+pub(crate) fn generate_random_suffix(length: usize) -> String {
     use rand::RngExt;
     let mut rng = rand::rng();
     (0..length)
@@ -39,38 +44,169 @@ fn get_exe_extension() -> &'static str {
     ""
 }
 
+pub(crate) fn is_hex_str(s: &str, len: usize) -> bool {
+    s.len() == len && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// Drop the NTFS MotW stream copied from a downloaded/installed exe.
+/// Missing ADS is ignored.
+pub(crate) fn strip_zone_identifier(path: &Path) {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::core::HSTRING;
+        use windows::Win32::Storage::FileSystem::DeleteFileW;
+
+        let ads = format!("{}:Zone.Identifier", path.display());
+        let _ = unsafe { DeleteFileW(&HSTRING::from(ads.as_str())) };
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = path;
+    }
+}
+
+fn paths_eq(a: &Path, b: &Path) -> bool {
+    match (fs::canonicalize(a), fs::canonicalize(b)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => a == b,
+    }
+}
+
+/// True when `exe` lives at `%TEMP%/<16 hex>/<12 hex>[.exe]`.
+fn is_stealth_copy_path(exe: &Path) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        match exe.extension().and_then(|ext| ext.to_str()) {
+            Some("exe") => {}
+            _ => return false,
+        }
+    }
+
+    let stem = exe.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    if !is_hex_str(stem, FILE_HEX_LEN) {
+        return false;
+    }
+
+    let parent = match exe.parent() {
+        Some(path) => path,
+        None => return false,
+    };
+    let parent_name = parent.file_name().and_then(|s| s.to_str()).unwrap_or("");
+    if !is_hex_str(parent_name, DIR_HEX_LEN) {
+        return false;
+    }
+
+    let temp_parent = match parent.parent() {
+        Some(path) => path,
+        None => return false,
+    };
+    paths_eq(temp_parent, &env::temp_dir())
+}
+
+fn window_title_for_exe(exe: &Path) -> String {
+    exe.file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("Runtime")
+        .to_string()
+}
+
+fn webview_user_data_dir_for_exe(exe: &Path) -> Option<PathBuf> {
+    exe.parent().map(|dir| dir.join(WEBVIEW_DATA_DIR_NAME))
+}
+
+fn is_legacy_svc_file_name(name: &str) -> bool {
+    if !name.starts_with(LEGACY_SVC_PREFIX) {
+        return false;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        name.ends_with(".exe")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        !name.contains('.')
+    }
+}
+
+fn is_legacy_cleanup_bat(name: &str) -> bool {
+    let Some(stem) = name.strip_suffix(".bat") else {
+        return false;
+    };
+    stem.starts_with("cleanup_")
+}
+
+fn is_removable_legacy_temp_file(name: &str) -> bool {
+    is_legacy_svc_file_name(name) || is_legacy_cleanup_bat(name)
+}
+
+fn remove_legacy_temp_file_if_needed(path: &Path) {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+    if !is_removable_legacy_temp_file(name) {
+        return;
+    }
+    match fs::remove_file(path) {
+        Ok(()) => println!("[Stealth] Cleaned up legacy file: {}", name),
+        Err(err) => {
+            if cfg!(debug_assertions) {
+                eprintln!("[Stealth] Failed to clean up {}: {}", name, err);
+            }
+        }
+    }
+}
+
+fn dir_looks_like_stealth_copy(dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let path = entry.path();
+        if !path.is_file() {
+            return false;
+        }
+        is_stealth_copy_path(&path)
+    })
+}
+
 /// Check if currently running in stealth mode
 pub fn is_stealth_mode() -> bool {
     IS_STEALTH_MODE.load(Ordering::Relaxed)
 }
 
-/// Generate a random window title that looks like a system process
+/// Window title for the stealth copy: the executable stem.
 pub fn generate_stealth_window_title() -> String {
-    use rand::RngExt;
+    env::current_exe()
+        .ok()
+        .map(|path| window_title_for_exe(&path))
+        .unwrap_or_else(|| "Runtime".to_string())
+}
 
-    // Pool of system-like window title patterns
-    let patterns = [
-        "Windows Update",
-        "Windows Defender",
-        "Background Task Host",
-        "Service Host",
-        "Runtime Broker",
-        "Settings",
-        "Microsoft Edge Update",
-        "Windows Security",
-        "System",
-        "Host Process",
-    ];
+/// WebView2 user-data directory beside the stealth copy (`ud/`).
+pub fn webview_user_data_dir() -> Option<PathBuf> {
+    if !is_stealth_mode() {
+        return None;
+    }
+    env::current_exe()
+        .ok()
+        .and_then(|path| webview_user_data_dir_for_exe(&path))
+}
 
-    let mut rng = rand::rng();
-    let pattern = patterns[rng.random_range(0..patterns.len())];
-
-    // Optionally add a random suffix
-    if rng.random_bool(0.5) {
-        let suffix = generate_random_suffix(4);
-        format!("{} ({})", pattern, suffix)
-    } else {
-        pattern.to_string()
+/// Set process identity that windowing APIs read before the first window.
+pub fn apply_process_identity() {
+    if !is_stealth_mode() {
+        return;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let app_id = generate_stealth_window_title();
+        let app_id = windows::core::HSTRING::from(app_id.as_str());
+        if let Err(err) =
+            unsafe { windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID(&app_id) }
+        {
+            eprintln!("[Stealth] Failed to set AppUserModelID: {err}");
+        }
     }
 }
 
@@ -106,78 +242,83 @@ pub fn ensure_stealth_mode() -> bool {
 
 #[cfg(not(debug_assertions))]
 fn ensure_stealth_mode_impl() -> bool {
-    // Get current executable info
     let current_exe = match env::current_exe() {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("[Stealth] Failed to get current exe path: {}", e);
-            return true; // Cannot get path, continue execution
+        Ok(path) => path,
+        Err(err) => {
+            eprintln!("[Stealth] Failed to get current exe path: {}", err);
+            return true;
         }
     };
 
-    let file_name = current_exe
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("");
-
-    // If already running with random name, mark and continue
-    if file_name.starts_with(MAIN_APP_PREFIX) {
+    if is_stealth_copy_path(&current_exe) {
         IS_STEALTH_MODE.store(true, Ordering::Relaxed);
-        println!("[Stealth] Running in stealth mode as: {}", file_name);
-
-        // Clean up old temp files
-        cleanup_old_temp_files(MAIN_APP_PREFIX);
-
+        println!(
+            "[Stealth] Running in stealth mode as: {}",
+            current_exe.display()
+        );
+        cleanup_old_stealth_copies(&current_exe);
         return true;
     }
 
     println!("[Stealth] Starting stealth mode transition...");
 
-    // Generate random name
-    let random_suffix = generate_random_suffix(8);
+    let dir_name = generate_random_suffix(DIR_HEX_LEN);
+    let file_stem = generate_random_suffix(FILE_HEX_LEN);
     let ext = get_exe_extension();
-    let temp_name = format!("{}{}{}", MAIN_APP_PREFIX, random_suffix, ext);
+    let stealth_dir = env::temp_dir().join(&dir_name);
+    let dest_name = format!("{file_stem}{ext}");
+    let dest_exe = stealth_dir.join(&dest_name);
 
-    // Copy to temp directory
-    let temp_dir = env::temp_dir();
-    let temp_exe = temp_dir.join(&temp_name);
-
-    println!("[Stealth] Copying to: {:?}", temp_exe);
-
-    if let Err(e) = fs::copy(&current_exe, &temp_exe) {
-        eprintln!("[Stealth] Failed to copy to temp: {}", e);
-        return true; // Copy failed, continue with original name
+    if let Err(err) = fs::create_dir_all(&stealth_dir) {
+        eprintln!("[Stealth] Failed to create stealth directory: {}", err);
+        return true;
     }
 
-    // Set executable permission (Unix)
+    println!("[Stealth] Copying to: {:?}", dest_exe);
+
+    if let Err(err) = fs::copy(&current_exe, &dest_exe) {
+        eprintln!("[Stealth] Failed to copy to temp: {}", err);
+        let _ = fs::remove_dir_all(&stealth_dir);
+        return true;
+    }
+
+    // copy -> MOTW strip -> PE rewrite -> CreateProcess -> exit. No Tauri
+    // or window setup in this parent process.
+    strip_zone_identifier(&dest_exe);
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Err(err) =
+            crate::stealth_pe::rewrite_copy_identity(&dest_exe, &dest_name, &file_stem)
+        {
+            eprintln!("[Stealth] Failed to rewrite version info: {err}");
+        }
+    }
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        if let Ok(metadata) = fs::metadata(&temp_exe) {
+        if let Ok(metadata) = fs::metadata(&dest_exe) {
             let mut perms = metadata.permissions();
             perms.set_mode(0o755);
-            let _ = fs::set_permissions(&temp_exe, perms);
+            let _ = fs::set_permissions(&dest_exe, perms);
         }
     }
 
-    // Launch new process
     let args: Vec<String> = env::args().skip(1).collect();
-
-    let spawn_result = spawn_detached_process(&temp_exe, &args);
-
-    match spawn_result {
-        Ok(_) => {
+    // Keep the original cwd so sidecar lookup still finds the install directory.
+    match spawn_detached_process(&dest_exe, &args) {
+        Ok(()) => {
             println!(
                 "[Stealth] Successfully spawned stealth process: {}",
-                temp_name
+                dest_name
             );
-            // Successfully launched new process, exit current process
             std::process::exit(0);
         }
-        Err(e) => {
-            eprintln!("[Stealth] Failed to spawn stealth process: {}", e);
-            let _ = fs::remove_file(&temp_exe);
-            true // Launch failed, continue with original name
+        Err(err) => {
+            eprintln!("[Stealth] Failed to spawn stealth process: {}", err);
+            let _ = fs::remove_dir_all(&stealth_dir);
+            true
         }
     }
 }
@@ -219,33 +360,45 @@ fn spawn_detached_process(exe_path: &PathBuf, args: &[String]) -> io::Result<()>
     Ok(())
 }
 
-/// Clean up old temp executables
-fn cleanup_old_temp_files(prefix: &str) {
+fn cleanup_old_stealth_copies(current_exe: &Path) {
     let temp_dir = env::temp_dir();
-    let current_exe = env::current_exe().ok();
-    let ext = get_exe_extension();
+    let current_dir = current_exe.parent();
 
-    if let Ok(entries) = fs::read_dir(&temp_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
+    let Ok(entries) = fs::read_dir(&temp_dir) else {
+        return;
+    };
 
-            // Skip currently running file
-            if Some(&path) == current_exe.as_ref() {
-                continue;
-            }
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if Some(path.as_path()) == Some(current_exe) {
+            continue;
+        }
+        if current_dir == Some(path.as_path()) {
+            continue;
+        }
 
-            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                if name.starts_with(prefix) && name.ends_with(ext) {
-                    // Try to delete old file
-                    match fs::remove_file(&path) {
-                        Ok(_) => println!("[Stealth] Cleaned up: {}", name),
-                        Err(e) => {
-                            if cfg!(debug_assertions) {
-                                eprintln!("[Stealth] Failed to clean up {}: {}", name, e);
-                            }
-                            // File might be in use, ignore in release builds
-                        }
-                    }
+        if path.is_file() {
+            remove_legacy_temp_file_if_needed(&path);
+            continue;
+        }
+
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !is_hex_str(name, DIR_HEX_LEN) {
+            continue;
+        }
+        if !dir_looks_like_stealth_copy(&path) {
+            continue;
+        }
+        match fs::remove_dir_all(&path) {
+            Ok(()) => println!("[Stealth] Cleaned up: {}", name),
+            Err(err) => {
+                if cfg!(debug_assertions) {
+                    eprintln!("[Stealth] Failed to clean up {}: {}", name, err);
                 }
             }
         }
@@ -260,44 +413,209 @@ pub fn cleanup_on_exit() {
         return;
     }
 
-    // Self-destruct current temp file
     if let Ok(current_exe) = env::current_exe() {
         schedule_self_deletion(&current_exe);
     }
 }
 
-/// Schedule self deletion (delayed delete)
+/// Schedule self deletion without spawning cmd/bat.
+/// Locked files are marked for reboot deletion when possible; next start
+/// `cleanup_old_stealth_copies` removes whatever remains.
 #[cfg(target_os = "windows")]
 fn schedule_self_deletion(exe_path: &Path) {
-    use std::os::windows::process::CommandExt;
-    const CREATE_NO_WINDOW: u32 = 0x08000000;
-
-    // Windows cannot directly delete running exe
-    // Use batch script for delayed deletion
-    let bat_content = format!(
-        "@echo off\n\
-         timeout /t 5 /nobreak >nul\n\
-         del /f /q \"{}\"\n\
-         del /f /q \"%~f0\"\n",
-        exe_path.display()
-    );
-
-    let bat_filename = format!("cleanup_{}.bat", generate_random_suffix(8));
-    let bat_path = env::temp_dir().join(bat_filename);
-
-    if fs::write(&bat_path, bat_content).is_ok() {
-        if let Some(bat_str) = bat_path.to_str() {
-            // Run hidden using CREATE_NO_WINDOW to avoid popup
-            let _ = Command::new("cmd")
-                .args(["/C", bat_str])
-                .creation_flags(CREATE_NO_WINDOW)
-                .spawn();
+    if let Some(ud) = webview_user_data_dir_for_exe(exe_path) {
+        remove_tree_best_effort(&ud);
+    }
+    let Some(parent) = exe_path.parent() else {
+        remove_tree_best_effort(exe_path);
+        return;
+    };
+    if let Ok(entries) = fs::read_dir(parent) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path == exe_path {
+                continue;
+            }
+            remove_tree_best_effort(&path);
         }
     }
+    remove_tree_best_effort(exe_path);
+    remove_tree_best_effort(parent);
+}
+
+#[cfg(target_os = "windows")]
+fn remove_tree_best_effort(path: &Path) {
+    let removed = if path.is_dir() {
+        fs::remove_dir_all(path).is_ok()
+    } else {
+        fs::remove_file(path).is_ok()
+    };
+    if !removed {
+        mark_delete_on_reboot(path);
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn mark_delete_on_reboot(path: &Path) {
+    use windows::core::{HSTRING, PCWSTR};
+    use windows::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_DELAY_UNTIL_REBOOT};
+
+    let existing = HSTRING::from(path.to_string_lossy().as_ref());
+    let _ = unsafe { MoveFileExW(&existing, PCWSTR::null(), MOVEFILE_DELAY_UNTIL_REBOOT) };
 }
 
 #[cfg(not(target_os = "windows"))]
 fn schedule_self_deletion(exe_path: &Path) {
-    // Unix systems can directly delete running files (just removes inode reference)
+    let parent = exe_path.parent().map(Path::to_path_buf);
     let _ = fs::remove_file(exe_path);
+    if let Some(parent) = parent {
+        if is_stealth_copy_path(exe_path) || dir_looks_like_stealth_copy(&parent) {
+            let _ = fs::remove_dir_all(&parent);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_hex_stealth_layout() {
+        let temp = env::temp_dir();
+        let dir = temp.join("0123456789abcdef");
+        let exe = if cfg!(windows) {
+            dir.join("c0ffee12beef.exe")
+        } else {
+            dir.join("c0ffee12beef")
+        };
+        assert!(is_stealth_copy_path(&exe));
+        assert_eq!(webview_user_data_dir_for_exe(&exe), Some(dir.join("ud")));
+    }
+
+    #[test]
+    fn rejects_product_exe_name() {
+        let exe = env::temp_dir().join("discord-quest-helper.exe");
+        assert!(!is_stealth_copy_path(&exe));
+    }
+
+    #[test]
+    fn rejects_legacy_svc_prefix() {
+        let exe = env::temp_dir().join("svc_deadbeef.exe");
+        assert!(!is_stealth_copy_path(&exe));
+        assert_eq!(is_legacy_svc_file_name("svc_deadbeef.exe"), cfg!(windows));
+        assert_eq!(is_legacy_svc_file_name("svc_deadbeef"), !cfg!(windows));
+    }
+
+    #[test]
+    fn rejects_uppercase_or_wrong_length_hex() {
+        let temp = env::temp_dir();
+        let exe = temp.join("0123456789ABCDEF").join("c0ffee12beef.exe");
+        assert!(!is_stealth_copy_path(&exe));
+        let exe = temp.join("0123456789abcde").join("c0ffee12beef.exe");
+        assert!(!is_stealth_copy_path(&exe));
+        let exe = temp.join("0123456789abcdef").join("c0ffee12bee.exe");
+        assert!(!is_stealth_copy_path(&exe));
+    }
+
+    #[test]
+    fn window_title_matches_stem() {
+        assert_eq!(
+            window_title_for_exe(Path::new(r"C:\Temp\abc\c0ffee12beef.exe")),
+            "c0ffee12beef"
+        );
+        assert_eq!(generate_random_suffix(12).len(), FILE_HEX_LEN);
+        let suffix = generate_random_suffix(16);
+        assert!(is_hex_str(&suffix, DIR_HEX_LEN));
+    }
+
+    #[test]
+    fn dir_with_hex_exe_is_stealth_copy() {
+        let dir = env::temp_dir().join(generate_random_suffix(DIR_HEX_LEN));
+        fs::create_dir_all(&dir).unwrap();
+        let exe_name = if cfg!(windows) {
+            format!("{}.exe", generate_random_suffix(FILE_HEX_LEN))
+        } else {
+            generate_random_suffix(FILE_HEX_LEN)
+        };
+        let exe = dir.join(&exe_name);
+        fs::write(&exe, b"test").unwrap();
+        assert!(is_stealth_copy_path(&exe));
+        assert!(dir_looks_like_stealth_copy(&dir));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn recognizes_legacy_cleanup_bat() {
+        assert!(is_legacy_cleanup_bat("cleanup_ab12cd34.bat"));
+        assert!(!is_legacy_cleanup_bat("cleanup_ab12cd34.exe"));
+        assert!(!is_legacy_cleanup_bat("notes.bat"));
+    }
+
+    #[test]
+    fn strip_zone_identifier_ignores_missing_ads() {
+        let path = env::temp_dir().join(format!("stealth-motw-{}.txt", generate_random_suffix(8)));
+        fs::write(&path, b"ok").unwrap();
+        strip_zone_identifier(&path);
+        assert!(path.exists());
+        let _ = fs::remove_file(&path);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strip_zone_identifier_removes_motw_when_present() {
+        let path = env::temp_dir().join(format!("stealth-motw-{}.txt", generate_random_suffix(8)));
+        fs::write(&path, b"ok").unwrap();
+        let ads = format!("{}:Zone.Identifier", path.display());
+        let wrote_ads = fs::write(&ads, "[ZoneTransfer]\r\nZoneId=3\r\n").is_ok();
+        strip_zone_identifier(&path);
+        if wrote_ads {
+            assert!(fs::read_to_string(&ads).is_err());
+        }
+        let _ = fs::remove_file(&path);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn exit_cleanup_does_not_write_bat() {
+        let dir = env::temp_dir().join(generate_random_suffix(DIR_HEX_LEN));
+        fs::create_dir_all(&dir).unwrap();
+        let ud = dir.join(WEBVIEW_DATA_DIR_NAME);
+        fs::create_dir_all(&ud).unwrap();
+        fs::write(ud.join("cache"), b"x").unwrap();
+        let exe = dir.join(format!("{}.exe", generate_random_suffix(FILE_HEX_LEN)));
+        fs::write(&exe, b"test").unwrap();
+
+        let before: Vec<_> = fs::read_dir(env::temp_dir())
+            .unwrap()
+            .flatten()
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|n| is_legacy_cleanup_bat(n))
+            .collect();
+
+        schedule_self_deletion(&exe);
+
+        let after: Vec<_> = fs::read_dir(env::temp_dir())
+            .unwrap()
+            .flatten()
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|n| is_legacy_cleanup_bat(n))
+            .collect();
+        assert_eq!(before, after);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn removes_legacy_cleanup_bat_from_a_directory() {
+        let dir = env::temp_dir().join(format!("stealth-bat-{}", generate_random_suffix(8)));
+        fs::create_dir_all(&dir).unwrap();
+        let bat = dir.join("cleanup_ab12cd34.bat");
+        let keep = dir.join("notes.bat");
+        fs::write(&bat, b"@echo off\r\n").unwrap();
+        fs::write(&keep, b"keep").unwrap();
+        remove_legacy_temp_file_if_needed(&bat);
+        remove_legacy_temp_file_if_needed(&keep);
+        assert!(!bat.exists());
+        assert!(keep.exists());
+        let _ = fs::remove_dir_all(&dir);
+    }
 }

--- a/src-tauri/src/stealth_pe.rs
+++ b/src-tauri/src/stealth_pe.rs
@@ -1,0 +1,337 @@
+//! Rewrite VERSIONINFO and strip icons on a copied Windows executable.
+//!
+//! Applied only to the stealth temp copy. The installed product binary is
+//! left unchanged.
+
+use std::path::Path;
+
+use windows::core::{BOOL, HSTRING, PCWSTR};
+use windows::Win32::Foundation::{FreeLibrary, HANDLE, HMODULE};
+use windows::Win32::Storage::FileSystem::{
+    GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
+};
+use windows::Win32::System::LibraryLoader::{
+    BeginUpdateResourceW, EndUpdateResourceW, EnumResourceLanguagesW, EnumResourceNamesW,
+    LoadLibraryExW, UpdateResourceW, LOAD_LIBRARY_AS_DATAFILE,
+};
+use windows::Win32::UI::WindowsAndMessaging::{RT_GROUP_ICON, RT_ICON, RT_VERSION};
+
+const VERSION_LANG: u16 = 0x0409;
+const STRING_TABLE_KEY: &str = "040904B0";
+
+#[derive(Clone)]
+enum ResourceId {
+    Id(u16),
+    Name(Vec<u16>),
+}
+
+impl ResourceId {
+    fn from_pcwstr(value: PCWSTR) -> Self {
+        let ptr = value.0 as usize;
+        if ptr >> 16 == 0 {
+            return Self::Id(ptr as u16);
+        }
+        let mut name = Vec::new();
+        unsafe {
+            let mut i = 0;
+            loop {
+                let ch = *value.0.add(i);
+                name.push(ch);
+                if ch == 0 {
+                    break;
+                }
+                i += 1;
+            }
+        }
+        Self::Name(name)
+    }
+
+    fn as_pcwstr(&self) -> PCWSTR {
+        match self {
+            Self::Id(id) => PCWSTR(*id as usize as *const u16),
+            Self::Name(name) => PCWSTR(name.as_ptr()),
+        }
+    }
+}
+
+/// Replace version strings on `exe` so they match `file_name` / `stem`,
+/// and delete icon resources.
+pub fn rewrite_copy_identity(exe: &Path, file_name: &str, stem: &str) -> Result<(), String> {
+    let blob = build_version_info(file_name, stem);
+    let icons = collect_resources(exe, RT_ICON);
+    let groups = collect_resources(exe, RT_GROUP_ICON);
+    let versions = collect_resources(exe, RT_VERSION);
+
+    let path = HSTRING::from(exe.to_string_lossy().as_ref());
+    let update = unsafe { BeginUpdateResourceW(&path, false) }
+        .map_err(|err| format!("BeginUpdateResourceW: {err}"))?;
+
+    let result = (|| {
+        delete_resources(update, RT_ICON, &icons)?;
+        delete_resources(update, RT_GROUP_ICON, &groups)?;
+        delete_resources(update, RT_VERSION, &versions)?;
+        unsafe {
+            UpdateResourceW(
+                update,
+                RT_VERSION,
+                PCWSTR(1u16 as usize as *const u16),
+                VERSION_LANG,
+                Some(blob.as_ptr().cast()),
+                blob.len() as u32,
+            )
+        }
+        .map_err(|err| format!("UpdateResourceW RT_VERSION: {err}"))
+    })();
+
+    let discard = result.is_err();
+    unsafe { EndUpdateResourceW(update, discard) }
+        .map_err(|err| format!("EndUpdateResourceW: {err}"))?;
+    result
+}
+
+fn delete_resources(
+    update: HANDLE,
+    resource_type: PCWSTR,
+    resources: &[(ResourceId, u16)],
+) -> Result<(), String> {
+    for (name, lang) in resources {
+        unsafe { UpdateResourceW(update, resource_type, name.as_pcwstr(), *lang, None, 0) }
+            .map_err(|err| format!("UpdateResourceW delete: {err}"))?;
+    }
+    Ok(())
+}
+
+fn collect_resources(path: &Path, resource_type: PCWSTR) -> Vec<(ResourceId, u16)> {
+    let mut out = Vec::new();
+    let path = HSTRING::from(path.to_string_lossy().as_ref());
+    let Ok(module) = (unsafe { LoadLibraryExW(&path, None, LOAD_LIBRARY_AS_DATAFILE) }) else {
+        return out;
+    };
+
+    unsafe {
+        let _ = EnumResourceNamesW(
+            Some(module),
+            resource_type,
+            Some(enum_resource_names),
+            &mut out as *mut Vec<(ResourceId, u16)> as isize,
+        );
+        let _ = FreeLibrary(module);
+    }
+    out
+}
+
+unsafe extern "system" fn enum_resource_names(
+    module: HMODULE,
+    lptype: PCWSTR,
+    lpname: PCWSTR,
+    lparam: isize,
+) -> BOOL {
+    let out = unsafe { &mut *(lparam as *mut Vec<(ResourceId, u16)>) };
+    let name = ResourceId::from_pcwstr(lpname);
+    let mut langs: Vec<u16> = Vec::new();
+    let _ = unsafe {
+        EnumResourceLanguagesW(
+            Some(module),
+            lptype,
+            lpname,
+            Some(enum_resource_langs),
+            &mut langs as *mut Vec<u16> as isize,
+        )
+    };
+    if langs.is_empty() {
+        langs.push(VERSION_LANG);
+        langs.push(0);
+    }
+    for lang in langs {
+        out.push((name.clone(), lang));
+    }
+    true.into()
+}
+
+unsafe extern "system" fn enum_resource_langs(
+    _module: HMODULE,
+    _lptype: PCWSTR,
+    _lpname: PCWSTR,
+    wlanguage: u16,
+    lparam: isize,
+) -> BOOL {
+    let langs = unsafe { &mut *(lparam as *mut Vec<u16>) };
+    langs.push(wlanguage);
+    true.into()
+}
+
+fn pad4(buf: &mut Vec<u8>) {
+    while !buf.len().is_multiple_of(4) {
+        buf.push(0);
+    }
+}
+
+fn utf16_nul(s: &str) -> Vec<u8> {
+    s.encode_utf16()
+        .chain(std::iter::once(0))
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect()
+}
+
+fn put_u16(buf: &mut Vec<u8>, value: u16) {
+    buf.extend_from_slice(&value.to_le_bytes());
+}
+
+fn put_u32(buf: &mut Vec<u8>, value: u32) {
+    buf.extend_from_slice(&value.to_le_bytes());
+}
+
+fn patch_length(buf: &mut [u8]) {
+    let len = buf.len() as u16;
+    buf[0..2].copy_from_slice(&len.to_le_bytes());
+}
+
+fn version_node(
+    key: &str,
+    w_type: u16,
+    value_length: u16,
+    value: &[u8],
+    children: &[u8],
+) -> Vec<u8> {
+    let mut inner = Vec::new();
+    put_u16(&mut inner, 0);
+    put_u16(&mut inner, value_length);
+    put_u16(&mut inner, w_type);
+    inner.extend_from_slice(&utf16_nul(key));
+    pad4(&mut inner);
+    inner.extend_from_slice(value);
+    if !value.is_empty() {
+        pad4(&mut inner);
+    }
+    inner.extend_from_slice(children);
+    patch_length(&mut inner);
+    inner
+}
+
+fn string_entry(key: &str, value: &str) -> Vec<u8> {
+    let value_bytes = utf16_nul(value);
+    version_node(key, 1, (value_bytes.len() / 2) as u16, &value_bytes, &[])
+}
+
+pub(crate) fn build_version_info(file_name: &str, stem: &str) -> Vec<u8> {
+    let mut strings = Vec::new();
+    strings.extend_from_slice(&string_entry("CompanyName", stem));
+    strings.extend_from_slice(&string_entry("FileDescription", stem));
+    strings.extend_from_slice(&string_entry("FileVersion", "1.0.0.0"));
+    strings.extend_from_slice(&string_entry("InternalName", stem));
+    strings.extend_from_slice(&string_entry("LegalCopyright", ""));
+    strings.extend_from_slice(&string_entry("OriginalFilename", file_name));
+    strings.extend_from_slice(&string_entry("ProductName", stem));
+    strings.extend_from_slice(&string_entry("ProductVersion", "1.0.0.0"));
+
+    let string_table = version_node(STRING_TABLE_KEY, 1, 0, &[], &strings);
+    let string_file_info = version_node("StringFileInfo", 1, 0, &[], &string_table);
+
+    let mut translation = Vec::new();
+    put_u32(&mut translation, 0x04B0_0409);
+    let var = version_node(
+        "Translation",
+        0,
+        translation.len() as u16,
+        &translation,
+        &[],
+    );
+    let var_file_info = version_node("VarFileInfo", 1, 0, &[], &var);
+
+    let mut fixed = Vec::new();
+    put_u32(&mut fixed, 0xFEEF_04BD); // dwSignature
+    put_u32(&mut fixed, 0x0001_0000); // dwStrucVersion
+    put_u32(&mut fixed, 0x0001_0000); // dwFileVersionMS 1.0
+    put_u32(&mut fixed, 0x0000_0000); // dwFileVersionLS 0.0
+    put_u32(&mut fixed, 0x0001_0000); // dwProductVersionMS
+    put_u32(&mut fixed, 0x0000_0000); // dwProductVersionLS
+    put_u32(&mut fixed, 0x0000_003F); // dwFileFlagsMask
+    put_u32(&mut fixed, 0); // dwFileFlags
+    put_u32(&mut fixed, 0x0004_0004); // dwFileOS VOS_NT_WINDOWS32
+    put_u32(&mut fixed, 0x0000_0001); // dwFileType VFT_APP
+    put_u32(&mut fixed, 0); // dwFileSubtype
+    put_u32(&mut fixed, 0); // dwFileDateMS
+    put_u32(&mut fixed, 0); // dwFileDateLS
+
+    let mut children = Vec::new();
+    children.extend_from_slice(&string_file_info);
+    children.extend_from_slice(&var_file_info);
+
+    version_node("VS_VERSION_INFO", 0, fixed.len() as u16, &fixed, &children)
+}
+
+pub(crate) fn query_version_string(path: &Path, key: &str) -> Result<String, String> {
+    let path_h = HSTRING::from(path.to_string_lossy().as_ref());
+    let mut handle = 0u32;
+    let size = unsafe { GetFileVersionInfoSizeW(&path_h, Some(&mut handle)) };
+    if size == 0 {
+        return Err("GetFileVersionInfoSizeW returned 0".to_string());
+    }
+    let mut buffer = vec![0u8; size as usize];
+    unsafe {
+        GetFileVersionInfoW(&path_h, Some(handle), size, buffer.as_mut_ptr().cast())
+            .map_err(|err| format!("GetFileVersionInfoW: {err}"))?;
+    }
+
+    let sub = HSTRING::from(format!("\\StringFileInfo\\{STRING_TABLE_KEY}\\{key}"));
+    let mut value: *mut core::ffi::c_void = std::ptr::null_mut();
+    let mut len = 0u32;
+    let ok = unsafe { VerQueryValueW(buffer.as_ptr().cast(), &sub, &mut value, &mut len) };
+    if !bool::from(ok) || value.is_null() {
+        return Err(format!("VerQueryValueW missing {key}"));
+    }
+    let text = unsafe { PCWSTR(value.cast()).to_string() }
+        .map_err(|err| format!("version string utf16: {err}"))?;
+    Ok(text.trim_end_matches('\0').to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+
+    #[test]
+    fn version_blob_contains_stem_utf16() {
+        let blob = build_version_info("c0ffee12beef.exe", "c0ffee12beef");
+        let product = "c0ffee12beef"
+            .encode_utf16()
+            .flat_map(|u| u.to_le_bytes())
+            .collect::<Vec<_>>();
+        assert!(blob.windows(product.len()).any(|w| w == product));
+        let leaked = "Discord Quest Helper"
+            .encode_utf16()
+            .flat_map(|u| u.to_le_bytes())
+            .collect::<Vec<_>>();
+        assert!(!blob.windows(leaked.len()).any(|w| w == leaked));
+    }
+
+    #[test]
+    fn rewrite_replaces_version_strings_on_copied_exe() {
+        let src = env::current_exe().expect("current_exe");
+        let dir = env::temp_dir().join(format!(
+            "stealth-pe-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let dest = dir.join("c0ffee12beef.exe");
+        fs::copy(&src, &dest).expect("copy test exe");
+
+        rewrite_copy_identity(&dest, "c0ffee12beef.exe", "c0ffee12beef")
+            .expect("rewrite_copy_identity");
+
+        let original = query_version_string(&dest, "OriginalFilename").expect("OriginalFilename");
+        let product = query_version_string(&dest, "ProductName").expect("ProductName");
+        let description = query_version_string(&dest, "FileDescription").expect("FileDescription");
+
+        assert_eq!(original, "c0ffee12beef.exe");
+        assert_eq!(product, "c0ffee12beef");
+        assert_eq!(description, "c0ffee12beef");
+        assert!(!product.contains("Discord Quest Helper"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,6 +13,8 @@
   "app": {
     "windows": [
       {
+        "label": "main",
+        "create": false,
         "title": "Discord Quest Helper",
         "width": 1200,
         "height": 800,


### PR DESCRIPTION
## Summary
- Shrink what Discord's process scanner can see from **runtime copies** of the app and CDP launcher on Windows, without changing the copy-rename-spawn-exit method.
- Main stealth copy is now `%TEMP%/<16 hex>/<12 hex>.exe` (no `svc_` prefix). Window title, AppUserModelID, and WebView2 data dir (`ud/`) match that stem. VERSIONINFO on the copy is rewritten and icons are stripped; MotW is dropped after copies.
- Parent process never builds Tauri/WebView: copy, rewrite PE, spawn, `exit(0)`. Exit no longer writes `cleanup_*.bat` / hidden `cmd`; leftover hex dirs and old bats are swept on the next stealth start.
- Windows **runtime** CDP launcher copy is a persistent LocalAppData hex path (pointer under AppData). Restore helper and shortcut **TargetPath** use it; the desktop file is still `Discord CDP Launcher.lnk`. Old `DiscordQuestHelper\DiscordCdpLauncher.exe` is migrated away.
- Simulated games spawn the runner directly with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` so `cmd.exe` does not appear. `CREATE_NO_WINDOW` is not used.

Installer `productName`, Start Menu name, bundled `discord-cdp-launcher-sidecar.exe`, macOS/Linux stable sidecar paths, and Linux stealth-disabled behavior are unchanged. This does not close #118 (eligibility blocks remain unexplained) and does not add PPID spoof / hollowing / svchost impersonation.

## Test plan
- [ ] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- [ ] Release Windows build: System Informer should show the hex temp copy after launch, not a long-lived `discord-quest-helper.exe` plus WebView2 under the product name. Original name is only visible during copy+PE+spawn.
- [ ] After quit, Temp should not get `cleanup_*.bat` / hidden `cmd`. Next launch should remove the previous hex directory.
- [ ] CDP restore / desktop shortcut: process image is not `DiscordCdpLauncher.exe` and the path is not `DiscordQuestHelper`. Desktop still shows `Discord CDP Launcher.lnk`.
- [ ] Simulated game start should not spawn a companion `cmd.exe`.
- [ ] Debug / `tauri dev` still skips stealth. macOS copy-relaunch uses hex names; Linux stealth stays off.

## Summary by Sourcery

Reduce Windows-visible product identity for runtime application and CDP launcher copies while eliminating shell-based process launching and cleanup.

New Features:
- Use randomized hexadecimal runtime paths and rewritten executable metadata for Windows stealth copies and the CDP launcher.
- Configure stealth windows and WebView2 data directories to match the randomized runtime identity.
- Launch simulated games directly with detached process flags instead of using cmd.exe.

Bug Fixes:
- Remove shell- and batch-based exit cleanup and replace it with direct cleanup and startup removal of stale runtime artifacts.
- Migrate the Windows CDP launcher away from the legacy product-named LocalAppData path while preserving shortcut behavior.
- Strip copied executable Mark-of-the-Web metadata and remove icons from runtime copies.

Enhancements:
- Keep the installed application identity and non-Windows stealth behavior unchanged while reducing runtime process visibility on Windows.

Build:
- Add the Windows API feature dependencies required for executable resource, filesystem, shell identity, and launcher changes.

Tests:
- Add coverage for randomized path validation, cleanup behavior, CDP runtime path migration, process flags, and Windows executable metadata rewriting.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reduces the Windows-visible identity of runtime application and CDP launcher copies while replacing shell-based process launch and cleanup behavior.

- Uses randomized executable paths and rewrites Windows resource metadata.
- Creates the main WebView with matching runtime identity and a colocated data directory.
- Persists the randomized CDP launcher path and migrates the legacy installation.
- Launches simulated games directly as detached processes.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because startup cleanup can still recursively delete an unrelated matching temporary directory.

The earlier reply states that requiring `ud/` fixes the cleanup matcher, but the current ownership check still relies only on that generic directory name and randomized filename layout before calling `remove_dir_all`, which is the concrete residual counterexample.

**Files Needing Attention:** src-tauri/src/stealth.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src-tauri/src/stealth.rs | Implements randomized stealth-copy identity, startup cleanup, and shell-free exit cleanup; the previously reported cleanup-ownership issue remains outstanding. |
| src-tauri/src/lib.rs | Builds the main WebView explicitly and adds persistent randomized Windows CDP launcher paths and migration. |
| src-tauri/src/stealth_pe.rs | Adds Windows PE resource rewriting for runtime executable copies. |
| src-tauri/src/game_simulator.rs | Replaces `cmd /C start` with direct detached Windows process creation. |
| src-tauri/Cargo.toml | Enables the additional Windows API feature sets required by the new runtime behavior. |
| src-tauri/tauri.conf.json | Updates window creation configuration to support explicit runtime construction. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(test): use portable paths in stealth..."](https://github.com/masterain98/discord-quest-helper/commit/3aa6c21d9c47ab3c852bd68dbf72065b994f5537) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55044448)</sub>

<!-- /greptile_comment -->